### PR TITLE
docs: Step 1〜7 の詳細実装プランを追加

### DIFF
--- a/docs/plans/rebuild-plan.md
+++ b/docs/plans/rebuild-plan.md
@@ -80,6 +80,7 @@ docs/
 | ルーティング | React Router v6 |
 | 開発環境 | Docker Compose |
 | メール(dev) | Mailpit |
+| 通知(UI) | react-hot-toast |
 
 ## アーキテクチャ方針
 
@@ -110,6 +111,38 @@ docs/
 | Family | 家族管理、子ども、招待 |
 | Bookshelf | 絵本登録・検索・本棚管理 |
 | ReadLog | 読み聞かせ記録、タグ |
+
+### コンテキスト間の Value Object 共有方針
+
+複数のコンテキストで `FamilyId`, `UserId` 等の識別子を使用する必要がある。
+
+| 方式 | 説明 |
+|---|---|
+| 各コンテキストに独自定義 | 完全な独立性。変換コストがある |
+| 共有カーネル（Shared Kernel） | 共通パッケージに ID 系 Value Object を集約 |
+| プリミティブ型で受け渡し | シンプルだが型安全性が低い |
+
+→ **共有カーネルを採用**。`packages/Shared/ValueObject/` に ID 系 Value Object（`UserId`, `FamilyId`, `ChildId`, `PictureBookId`）と汎用 Value Object（`Email`）を配置し、各コンテキストから参照する。
+
+```
+backend/packages/
+├── Shared/
+│   └── ValueObject/
+│       ├── UserId.php
+│       ├── FamilyId.php
+│       ├── ChildId.php
+│       ├── PictureBookId.php
+│       └── Email.php
+├── Auth/
+├── Family/
+├── Bookshelf/
+└── ReadLog/
+```
+
+理由:
+- ID 系 Value Object はどのコンテキストでも同一の不変条件（正の整数）を持ち、コンテキスト固有のロジックがない
+- 各コンテキストに同名クラスを重複定義するのは保守コストが高い
+- 個人開発アプリの規模では、過度なコンテキスト分離よりも実用性を優先する
 
 ## コア機能（Phase 1）
 
@@ -383,20 +416,68 @@ GET    /api/v1/tags?q={query}
 - `child_read_record` ピボットに `reaction` カラム追加（子ども毎のリアクション）
 - `family_invitations` に `expires_at` 追加
 - Phase 1不要のテーブル削除（contacts, follows, likes）
+- Phase 1不要のカラム削除（`users.role`, `users.avatar_path` は Phase 2 以降で追加）
+- `users.soft_delete` は Phase 1 では採用しない（物理削除。Phase 2 で必要に応じて導入）
 
 ### テーブル一覧
 
 | テーブル | 主なカラム |
 |---|---|
 | families | id, name |
-| users | id, family_id(nullable), name, email, password, role, avatar_path, soft_delete |
-| children | id, family_id, name, birthday |
+| users | id, family_id(nullable), name, email, password |
+| children | id, family_id, name, birthday(nullable) |
 | picture_books | id, family_id, registered_by, google_books_id, isbn, title, authors(JSON), thumbnail_url, rating(1-5), read_status, review |
 | read_records | id, picture_book_id, family_id, recorded_by, read_date, memo |
 | child_read_record | child_id, read_record_id, reaction |
 | tags | id, name(unique) |
 | read_record_tag | read_record_id, tag_id |
 | family_invitations | id, family_id, invited_by, email, token, accepted_at, expires_at |
+
+---
+
+## デプロイ構成
+
+### 方針
+
+- **フロントエンド（React SPA）**: Cloudflare Pages（無料）で静的配信
+- **バックエンド（Laravel API）+ DB（MySQL）**: ConoHa VPS 1台に Docker Compose でデプロイ
+- **SSL**: Let's Encrypt (certbot)
+- **ドメイン管理・DNS**: Cloudflare
+
+### 費用見積もり
+
+| 項目 | サービス | 費用 |
+|---|---|---|
+| VPS | ConoHa VPS 1GBプラン | 約750円/月 |
+| フロントエンド | Cloudflare Pages | 無料 |
+| SSL | Let's Encrypt | 無料 |
+| ドメイン | Cloudflare Registrar 等 | 年$10程度 |
+
+### 本番 Docker Compose 構成
+
+```
+VPS (ConoHa)
+├── docker-compose.prod.yml
+├── app        (PHP-FPM + Laravel API)
+├── web        (Nginx - リバースプロキシ + SSL終端)
+├── db         (MySQL 8.0 - ボリューム永続化)
+└── certbot    (Let's Encrypt 自動更新)
+```
+
+- 開発環境から `frontend` / `mailpit` コンテナを除外
+- Nginx に SSL (Let's Encrypt) 設定を追加
+- MySQL データはnamed volumeで永続化
+- 全コンテナに `restart: always` を設定
+- 環境変数は `.env` で管理（Git管理外）
+
+### デプロイフロー
+
+```
+[Frontend] Git push → Cloudflare Pages が自動ビルド・デプロイ
+[Backend]  Git push → VPSにSSH → git pull → docker compose -f docker-compose.prod.yml build → up -d
+```
+
+将来的に GitHub Actions で Backend のデプロイも自動化する。
 
 ---
 

--- a/docs/plans/step1-project-setup.md
+++ b/docs/plans/step1-project-setup.md
@@ -1,0 +1,487 @@
+# Step 1: プロジェクト基盤構築 — 詳細プラン
+
+## ゴール
+
+Docker Compose で Laravel API + React SPA + MySQL + Nginx + Mailpit が起動し、各コンテナ間の疎通が確認できる状態にする。
+
+## 完了条件
+
+- [ ] `task up` で全5コンテナが正常起動する
+- [ ] `curl http://localhost:8080/api/health` で Laravel API から JSON レスポンスが返る
+- [ ] `http://localhost:5173` で React の初期画面が表示される
+- [ ] Laravel から MySQL への接続が成功する（`task artisan migrate` が通る）
+- [ ] Mailpit の Web UI (`http://localhost:8025`) にアクセスできる
+- [ ] `task test` で PHPUnit のデフォルトテストが通る
+
+---
+
+## 1-1. Laravel プロジェクト作成
+
+### 作業内容
+
+```bash
+composer create-project laravel/laravel backend
+```
+
+### 作成後の調整
+
+- `backend/.env` を本番用ではなく Docker 用に調整（DB_HOST=db 等）
+- 不要なフロントエンド関連を削除:
+  - `backend/vite.config.js` — 削除（フロントは別コンテナ）
+  - `backend/resources/js/`, `backend/resources/css/` — 削除
+  - `backend/package.json` — 削除
+- `backend/routes/api.php` にヘルスチェック用エンドポイント追加:
+  ```php
+  Route::get('/health', fn () => response()->json(['status' => 'ok']));
+  ```
+- `backend/.gitignore` に `/vendor` が含まれていることを確認
+
+### packages ディレクトリの準備
+
+DDD用のディレクトリ構造を作成（空ディレクトリに `.gitkeep` を配置）:
+
+```
+backend/packages/
+├── Auth/
+│   ├── Application/
+│   │   ├── Command/
+│   │   └── Query/
+│   ├── Domain/
+│   │   ├── Entity/
+│   │   ├── ValueObject/
+│   │   └── Repository/
+│   └── Infrastructure/
+│       └── Repository/
+├── Family/
+│   ├── Application/
+│   │   ├── Command/
+│   │   └── Query/
+│   ├── Domain/
+│   │   ├── Entity/
+│   │   ├── ValueObject/
+│   │   ├── Repository/
+│   │   └── Service/
+│   └── Infrastructure/
+│       ├── Repository/
+│       └── Mail/
+├── Bookshelf/
+│   ├── Application/
+│   │   ├── Command/
+│   │   └── Query/
+│   ├── Domain/
+│   │   ├── Entity/
+│   │   ├── ValueObject/
+│   │   └── Repository/
+│   └── Infrastructure/
+│       ├── Repository/
+│       └── External/
+└── ReadLog/
+    ├── Application/
+    │   ├── Command/
+    │   └── Query/
+    ├── Domain/
+    │   ├── Entity/
+    │   ├── ValueObject/
+    │   └── Repository/
+    └── Infrastructure/
+        └── Repository/
+```
+
+### composer.json の autoload 設定
+
+packages を PSR-4 で読み込めるように設定:
+
+```json
+{
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/",
+      "Packages\\Auth\\": "packages/Auth/",
+      "Packages\\Family\\": "packages/Family/",
+      "Packages\\Bookshelf\\": "packages/Bookshelf/",
+      "Packages\\ReadLog\\": "packages/ReadLog/"
+    }
+  }
+}
+```
+
+### 確認ポイント
+
+- `php artisan --version` で Laravel 11+ であること
+- `composer dump-autoload` が成功すること
+
+---
+
+## 1-2. React プロジェクト作成
+
+### 作業内容
+
+```bash
+npm create vite@latest frontend -- --template react-ts
+cd frontend && npm install
+```
+
+### 追加パッケージ（最小限）
+
+Step 1 では API 通信やルーティングはまだ不要。Vite の dev server が起動することだけ確認する。
+
+### Vite 設定調整
+
+`frontend/vite.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',  // Docker コンテナ外からアクセス可能にする
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://web:80',  // Nginx コンテナへプロキシ
+        changeOrigin: true,
+      },
+    },
+  },
+})
+```
+
+### 確認ポイント
+
+- `npm run dev` でVite dev serverが起動すること
+- ブラウザで初期画面が表示されること
+
+---
+
+## 1-3. Docker 環境構築
+
+### ディレクトリ構成
+
+```
+infra/docker/
+├── php/
+│   └── Dockerfile
+├── nginx/
+│   ├── Dockerfile        # （もしくは docker-compose で直接 image 指定）
+│   └── default.conf
+└── mysql/
+    └── my.cnf            # 文字コード設定等
+```
+
+### 1-3a. PHP Dockerfile (`infra/docker/php/Dockerfile`)
+
+```dockerfile
+FROM php:8.3-fpm-alpine
+
+# 必要な拡張
+RUN apk add --no-cache \
+    && docker-php-ext-install pdo_mysql bcmath
+
+# Composer インストール
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+```
+
+ポイント:
+- Alpine ベースで軽量化
+- `pdo_mysql`: MySQL接続に必須
+- `bcmath`: Laravelの一部機能で使用
+- Composer はマルチステージビルドで取得
+
+### 1-3b. Nginx 設定 (`infra/docker/nginx/default.conf`)
+
+```nginx
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html/public;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}
+```
+
+### 1-3c. MySQL 設定 (`infra/docker/mysql/my.cnf`)
+
+```ini
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[client]
+default-character-set=utf8mb4
+```
+
+### 1-3d. docker-compose.yml
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: infra/docker/php/Dockerfile
+    volumes:
+      - ./backend:/var/www/html
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - DB_HOST=db
+      - DB_DATABASE=${DB_DATABASE:-picture_book_log}
+      - DB_USERNAME=${DB_USERNAME:-app_user}
+      - DB_PASSWORD=${DB_PASSWORD:-secret}
+
+  web:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./backend:/var/www/html
+      - ./infra/docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - app
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpass}
+      MYSQL_DATABASE: ${DB_DATABASE:-picture_book_log}
+      MYSQL_USER: ${DB_USERNAME:-app_user}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-secret}
+    volumes:
+      - db-data:/var/lib/mysql
+      - ./infra/docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - frontend-node-modules:/app/node_modules
+    command: sh -c "npm install && npm run dev"
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"   # Web UI
+      - "1025:1025"   # SMTP
+
+volumes:
+  db-data:
+  frontend-node-modules:
+```
+
+ポイント:
+- `db` に `healthcheck` を設定し、`app` は DB が ready になってから起動
+- `frontend-node-modules` を named volume にして、ホスト側の node_modules と競合しない
+- ポートマッピング: API=8080, Frontend=5173, Mailpit UI=8025
+
+### 1-3e. .env.example
+
+```env
+# Database
+DB_DATABASE=picture_book_log
+DB_USERNAME=app_user
+DB_PASSWORD=secret
+DB_ROOT_PASSWORD=rootpass
+```
+
+### 確認ポイント
+
+- `docker compose up -d` で全5コンテナが `running` / `healthy` になる
+- `docker compose ps` で状態確認
+- `docker compose logs app` でPHP-FPMエラーがないこと
+
+---
+
+## 1-4. Laravel の環境設定
+
+### backend/.env（Docker用）
+
+```env
+APP_NAME="Picture Book Log"
+APP_ENV=local
+APP_KEY=   # php artisan key:generate で生成
+APP_DEBUG=true
+APP_URL=http://localhost:8080
+
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=picture_book_log
+DB_USERNAME=app_user
+DB_PASSWORD=secret
+
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_FROM_ADDRESS="noreply@picturebooklog.local"
+MAIL_FROM_NAME="${APP_NAME}"
+
+SESSION_DRIVER=cookie
+CACHE_STORE=file
+QUEUE_CONNECTION=sync
+```
+
+### 作業手順
+
+```bash
+# コンテナ内で実行
+docker compose exec app composer install
+docker compose exec app php artisan key:generate
+docker compose exec app php artisan migrate
+```
+
+### 確認ポイント
+
+- `php artisan migrate` が成功する
+- `curl http://localhost:8080/api/health` → `{"status":"ok"}`
+
+---
+
+## 1-5. Taskfile.yml 作成
+
+タスクランナーとして [Task](https://taskfile.dev/) を使用。よく使うコマンドをショートカット化する。
+
+```yaml
+version: '3'
+
+tasks:
+  up:
+    desc: 全コンテナを起動
+    cmds:
+      - docker compose up -d
+
+  down:
+    desc: 全コンテナを停止
+    cmds:
+      - docker compose down
+
+  restart:
+    desc: 全コンテナを再起動
+    cmds:
+      - docker compose restart
+
+  logs:
+    desc: ログ表示
+    cmds:
+      - docker compose logs -f {{.CLI_ARGS}}
+
+  ps:
+    desc: コンテナ状態確認
+    cmds:
+      - docker compose ps
+
+  artisan:
+    desc: php artisan コマンド実行
+    cmds:
+      - docker compose exec app php artisan {{.CLI_ARGS}}
+
+  migrate:
+    desc: マイグレーション実行
+    cmds:
+      - docker compose exec app php artisan migrate
+
+  seed:
+    desc: シーダー実行
+    cmds:
+      - docker compose exec app php artisan db:seed
+
+  fresh:
+    desc: DBリセット + マイグレーション + シーダー
+    cmds:
+      - docker compose exec app php artisan migrate:fresh --seed
+
+  test:
+    desc: PHPUnit テスト実行
+    cmds:
+      - docker compose exec app php artisan test
+
+  composer:
+    desc: Composer コマンド実行
+    cmds:
+      - docker compose exec app composer {{.CLI_ARGS}}
+
+  npm:
+    desc: npm コマンド実行（frontend コンテナ）
+    cmds:
+      - docker compose exec frontend npm {{.CLI_ARGS}}
+
+  shell:
+    desc: app コンテナに入る
+    cmds:
+      - docker compose exec app sh
+```
+
+### 確認ポイント
+
+- `task up` → 全コンテナ起動
+- `task migrate` → マイグレーション成功
+- `task test` → テスト通過
+
+---
+
+## 1-6. 疎通確認チェックリスト
+
+すべての作業完了後、以下を順に確認する:
+
+| # | 確認項目 | コマンド / URL | 期待結果 |
+|---|---|---|---|
+| 1 | コンテナ起動 | `task up && task ps` | 5コンテナすべて running |
+| 2 | API ヘルスチェック | `curl http://localhost:8080/api/health` | `{"status":"ok"}` |
+| 3 | DB 接続 | `task migrate` | マイグレーション成功 |
+| 4 | React 画面 | ブラウザで `http://localhost:5173` | Vite + React 初期画面 |
+| 5 | Mailpit | ブラウザで `http://localhost:8025` | Mailpit Web UI 表示 |
+| 6 | テスト | `task test` | PHPUnit テスト通過 |
+| 7 | API プロキシ | フロントから `/api/health` fetch | JSON レスポンス取得 |
+
+---
+
+## 作業順序まとめ
+
+```
+1-1. Laravel プロジェクト作成 + DDD ディレクトリ準備
+         ↓
+1-2. React プロジェクト作成 + Vite 設定
+         ↓
+1-3. Docker 環境構築（Dockerfile, nginx, mysql, docker-compose.yml）
+         ↓
+1-4. Laravel 環境設定（.env, key:generate, migrate）
+         ↓
+1-5. Taskfile.yml 作成
+         ↓
+1-6. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **packages ディレクトリ**: Step 1 では空ディレクトリ + `.gitkeep` のみ。実際のコードは Step 2 以降で追加
+- **Eloquent Models の配置**: `backend/database/Eloquent/Models/` に配置する方針だが、Step 1 では Laravel デフォルトの `app/Models/User.php` をそのまま残す。Step 2 で認証実装時に移動を検討
+- **node_modules**: Docker の named volume で管理し、ホスト側にはインストールしない方針
+- **Task (taskfile.dev)**: ホストマシンに `task` コマンドがインストールされている前提。未インストールなら `brew install go-task` で導入

--- a/docs/plans/step2-authentication.md
+++ b/docs/plans/step2-authentication.md
@@ -1,0 +1,718 @@
+# Step 2: 認証 (Authentication) — 詳細プラン
+
+## ゴール
+
+Laravel Sanctum によるトークンベース認証を実装し、React SPA からユーザー登録・ログイン・ログアウト・ユーザー情報取得ができる状態にする。
+Auth コンテキストを DDD + Clean Architecture + CQRS の構成で実装する最初のステップ。
+
+## 完了条件
+
+- [ ] `POST /api/v1/auth/register` でユーザー登録でき、トークンが返る
+- [ ] `POST /api/v1/auth/login` でログインでき、トークンが返る
+- [ ] `POST /api/v1/auth/logout` でトークンが無効化される
+- [ ] `GET /api/v1/auth/user` で認証済みユーザー情報が取得できる
+- [ ] 未認証で保護エンドポイントにアクセスすると 401 が返る
+- [ ] React SPA から登録・ログイン・ログアウトの一連のフローが動作する
+- [ ] ProtectedRoute により未認証ユーザーがログインページにリダイレクトされる
+- [ ] Feature テストが全て通る
+
+---
+
+## 2-1. Sanctum セットアップ
+
+### 作業内容
+
+```bash
+docker compose exec app composer require laravel/sanctum
+docker compose exec app php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider"
+docker compose exec app php artisan migrate
+```
+
+### 設定ファイル
+
+**`config/sanctum.php`**:
+- `stateful` ドメインの設定は不要（SPA Cookie 認証ではなくトークンベースを使用）
+- トークンの有効期限: `'expiration' => null`（無期限、ログアウトで明示的に削除）
+
+**`config/cors.php`**:
+```php
+return [
+    'paths' => ['api/*'],
+    'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:5173')],
+    'allowed_methods' => ['*'],
+    'allowed_headers' => ['*'],
+    'supports_credentials' => true,
+];
+```
+
+**`backend/.env` に追加**:
+```env
+FRONTEND_URL=http://localhost:5173
+```
+
+### 設計判断: SPA Cookie 認証 vs トークンベース
+
+Sanctum には 2 つの認証方式がある:
+
+| 方式 | 仕組み | 適するケース |
+|---|---|---|
+| SPA Cookie 認証 | CSRF トークン + セッション Cookie | 同一ドメイン / サブドメインの SPA |
+| API トークン認証 | `Authorization: Bearer {token}` ヘッダー | 完全分離の SPA、モバイルアプリ |
+
+**トークンベースを選択する理由**:
+- フロントエンド (Cloudflare Pages) とバックエンド (ConoHa VPS) が異なるドメインになる本番構成
+- CSRF トークン取得の `/sanctum/csrf-cookie` エンドポイントが不要でシンプル
+- 将来的にモバイルアプリ対応も可能
+
+### 確認ポイント
+
+- `personal_access_tokens` マイグレーションが実行される
+- `config/sanctum.php` が存在する
+
+---
+
+## 2-2. Auth コンテキスト — Domain 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Auth/
+├── Domain/
+│   ├── Entity/
+│   │   └── User.php              # ドメインエンティティ
+│   ├── ValueObject/
+│   │   ├── UserId.php
+│   │   ├── Email.php
+│   │   ├── UserName.php
+│   │   └── HashedPassword.php
+│   └── Repository/
+│       └── UserRepositoryInterface.php
+```
+
+### Domain Entity: `User`
+
+```php
+namespace Packages\Auth\Domain\Entity;
+
+final class User
+{
+    public function __construct(
+        private readonly UserId $id,
+        private readonly UserName $name,
+        private readonly Email $email,
+        private readonly HashedPassword $password,
+    ) {}
+
+    // Getter メソッド
+    // ファクトリメソッド: createNew (登録時), reconstruct (DB復元時)
+}
+```
+
+### Value Objects
+
+| クラス | バリデーション |
+|---|---|
+| `UserId` | 正の整数 |
+| `Email` | メール形式（`filter_var`） |
+| `UserName` | 1〜255文字 |
+| `HashedPassword` | bcrypt ハッシュ済み文字列をラップ |
+
+### Repository Interface
+
+```php
+namespace Packages\Auth\Domain\Repository;
+
+interface UserRepositoryInterface
+{
+    public function findByEmail(Email $email): ?User;
+    public function save(User $user): User;
+}
+```
+
+### 設計判断メモ
+
+- **Value Object のバリデーション**: コンストラクタで不変条件を検証し、不正な値は `InvalidArgumentException` をスロー。Laravel の FormRequest バリデーションとは別に、ドメイン層でも最低限の検証を行う
+- **HashedPassword**: 平文パスワードは Domain 層に持ち込まない。ハッシュ化は Application 層（Command Handler）で行い、Domain には HashedPassword として渡す
+- **User Entity の ID**: 登録時は DB 採番前なので `UserId` は nullable にするか、`createNew` では ID なしで生成し `save` 後に ID 付きで返す設計にする
+
+---
+
+## 2-3. Auth コンテキスト — Application 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Auth/
+├── Application/
+│   ├── Command/
+│   │   ├── RegisterUser/
+│   │   │   ├── RegisterUserCommand.php    # 入力DTO
+│   │   │   └── RegisterUserHandler.php    # ユースケース
+│   │   ├── Login/
+│   │   │   ├── LoginCommand.php
+│   │   │   └── LoginHandler.php
+│   │   └── Logout/
+│   │       ├── LogoutCommand.php
+│   │       └── LogoutHandler.php
+│   └── Query/
+│       └── GetCurrentUser/
+│           ├── GetCurrentUserQuery.php
+│           └── GetCurrentUserHandler.php
+```
+
+### RegisterUser
+
+**`RegisterUserCommand`** (DTO):
+```php
+final class RegisterUserCommand
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $email,
+        public readonly string $password,
+    ) {}
+}
+```
+
+**`RegisterUserHandler`**:
+1. Email の重複チェック（Repository 経由）
+2. パスワードをハッシュ化
+3. Domain Entity `User::createNew()` 生成
+4. Repository で永続化
+5. トークン生成（Sanctum）して返却
+
+### Login
+
+**`LoginHandler`**:
+1. Email でユーザー検索
+2. パスワード照合（`Hash::check`）
+3. 失敗時は例外スロー
+4. 成功時にトークン生成して返却
+
+### Logout
+
+**`LogoutHandler`**:
+1. 現在のアクセストークンを削除（`$user->currentAccessToken()->delete()`）
+
+### GetCurrentUser (Query)
+
+**`GetCurrentUserHandler`**:
+- CQRS の Query 側。Eloquent を直接使って現在のユーザー情報を取得
+- Domain Entity を経由せず、DTO またはそのまま Eloquent Model を返す
+
+### 設計判断: トークン生成の責務
+
+トークン生成（`createToken`）は Sanctum（Infrastructure 層）に依存する。選択肢:
+
+1. **Handler 内で Eloquent Model 経由で直接呼ぶ** — シンプルだが Application 層が Infrastructure に依存
+2. **TokenServiceInterface を Domain/Application に定義し、Infrastructure で実装** — 純粋だが過剰
+
+→ **選択肢 1 を採用**。認証トークン生成は Auth コンテキスト固有の関心事であり、他コンテキストに波及しない。過度な抽象化を避け、Handler 内で Eloquent User Model の `createToken` を呼ぶ。
+
+---
+
+## 2-4. Auth コンテキスト — Infrastructure 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Auth/
+└── Infrastructure/
+    └── Repository/
+        └── EloquentUserRepository.php
+```
+
+### EloquentUserRepository
+
+```php
+namespace Packages\Auth\Infrastructure\Repository;
+
+use App\Models\User as EloquentUser;
+use Packages\Auth\Domain\Entity\User;
+use Packages\Auth\Domain\Repository\UserRepositoryInterface;
+
+final class EloquentUserRepository implements UserRepositoryInterface
+{
+    public function findByEmail(Email $email): ?User
+    {
+        $eloquentUser = EloquentUser::where('email', $email->value())->first();
+        if ($eloquentUser === null) {
+            return null;
+        }
+        return $this->toDomainEntity($eloquentUser);
+    }
+
+    public function save(User $user): User
+    {
+        $eloquentUser = EloquentUser::create([
+            'name' => $user->name()->value(),
+            'email' => $user->email()->value(),
+            'password' => $user->password()->value(),
+        ]);
+        return $this->toDomainEntity($eloquentUser);
+    }
+
+    private function toDomainEntity(EloquentUser $model): User
+    {
+        return User::reconstruct(
+            new UserId($model->id),
+            new UserName($model->name),
+            new Email($model->email),
+            new HashedPassword($model->password),
+        );
+    }
+}
+```
+
+### ServiceProvider でのバインド
+
+`App\Providers\AppServiceProvider` または専用の `AuthServiceProvider`:
+
+```php
+$this->app->bind(
+    UserRepositoryInterface::class,
+    EloquentUserRepository::class,
+);
+```
+
+---
+
+## 2-5. Interface 層 — Controller, Request, Resource, Routes
+
+### ディレクトリ構成
+
+```
+backend/app/Http/
+├── Controllers/Api/
+│   └── AuthController.php
+├── Requests/
+│   ├── RegisterRequest.php
+│   └── LoginRequest.php
+└── Resources/
+    └── UserResource.php
+```
+
+### AuthController
+
+```php
+namespace App\Http\Controllers\Api;
+
+class AuthController extends Controller
+{
+    // POST /api/v1/auth/register
+    public function register(RegisterRequest $request, RegisterUserHandler $handler)
+
+    // POST /api/v1/auth/login
+    public function login(LoginRequest $request, LoginHandler $handler)
+
+    // POST /api/v1/auth/logout (auth:sanctum)
+    public function logout(Request $request, LogoutHandler $handler)
+
+    // GET /api/v1/auth/user (auth:sanctum)
+    public function user(Request $request, GetCurrentUserHandler $handler)
+}
+```
+
+### FormRequest バリデーション
+
+**`RegisterRequest`**:
+| フィールド | ルール |
+|---|---|
+| `name` | `required`, `string`, `max:255` |
+| `email` | `required`, `string`, `email`, `max:255`, `unique:users` |
+| `password` | `required`, `string`, `min:8`, `confirmed` |
+
+**`LoginRequest`**:
+| フィールド | ルール |
+|---|---|
+| `email` | `required`, `string`, `email` |
+| `password` | `required`, `string` |
+
+### UserResource
+
+```php
+namespace App\Http\Resources;
+
+class UserResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'created_at' => $this->created_at->toISOString(),
+        ];
+    }
+}
+```
+
+### API レスポンス形式
+
+**登録・ログイン成功**:
+```json
+{
+  "user": {
+    "id": 1,
+    "name": "John",
+    "email": "john@example.com",
+    "created_at": "2026-03-07T00:00:00.000000Z"
+  },
+  "token": "1|xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+**ログアウト成功**:
+```json
+{
+  "message": "Logged out successfully"
+}
+```
+
+**バリデーションエラー (422)**:
+```json
+{
+  "message": "The email has already been taken.",
+  "errors": {
+    "email": ["The email has already been taken."]
+  }
+}
+```
+
+**認証エラー (401)**:
+```json
+{
+  "message": "Unauthenticated."
+}
+```
+
+### ルート定義 (`routes/api.php`)
+
+```php
+Route::prefix('v1/auth')->group(function () {
+    Route::post('/register', [AuthController::class, 'register']);
+    Route::post('/login', [AuthController::class, 'login']);
+
+    Route::middleware('auth:sanctum')->group(function () {
+        Route::post('/logout', [AuthController::class, 'logout']);
+        Route::get('/user', [AuthController::class, 'user']);
+    });
+});
+```
+
+---
+
+## 2-6. Eloquent Model の調整
+
+### `app/Models/User.php`
+
+Laravel デフォルトの User モデルに Sanctum の `HasApiTokens` トレイトを追加:
+
+```php
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens, HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+}
+```
+
+### 設計判断: Eloquent Model の配置
+
+rebuild-plan では `database/Eloquent/Models/` への移動を検討していたが、Step 2 では Laravel デフォルトの `app/Models/` をそのまま使う。理由:
+- Sanctum の `HasApiTokens` など Laravel 標準機能との統合が容易
+- `auth.php` の `providers.users.model` 設定変更が不要
+- 移動のメリットがまだ明確でないため、必要性が出てから判断する
+
+---
+
+## 2-7. Feature テスト
+
+### テストファイル
+
+```
+backend/tests/Feature/
+└── Auth/
+    ├── RegisterTest.php
+    ├── LoginTest.php
+    ├── LogoutTest.php
+    └── GetCurrentUserTest.php
+```
+
+### テストケース一覧
+
+**RegisterTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常な入力で登録 | 201, user + token 返却 |
+| 2 | email 重複 | 422, バリデーションエラー |
+| 3 | password が 8 文字未満 | 422 |
+| 4 | password_confirmation 不一致 | 422 |
+| 5 | 必須フィールド欠落 | 422 |
+
+**LoginTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正しい認証情報でログイン | 200, user + token 返却 |
+| 2 | メールアドレスが存在しない | 401 or 422 |
+| 3 | パスワード不一致 | 401 or 422 |
+
+**LogoutTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 認証済みユーザーがログアウト | 200, トークン無効化 |
+| 2 | 未認証でログアウト試行 | 401 |
+
+**GetCurrentUserTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 認証済みでユーザー情報取得 | 200, user 情報返却 |
+| 2 | 未認証でアクセス | 401 |
+
+### テスト環境
+
+- `phpunit.xml` で SQLite in-memory または MySQL テスト用 DB を使用
+- `RefreshDatabase` トレイトでテスト毎に DB リセット
+
+---
+
+## 2-8. フロントエンド — 追加パッケージ
+
+### インストール
+
+```bash
+docker compose exec frontend npm install axios react-router-dom react-hook-form
+docker compose exec frontend npm install -D @types/react-router-dom
+```
+
+| パッケージ | 用途 |
+|---|---|
+| `axios` | API クライアント |
+| `react-router-dom` | SPA ルーティング |
+| `react-hook-form` | フォーム管理 |
+
+> TanStack Query は Step 3 以降で導入。Step 2 では Axios + useEffect でシンプルに実装する。
+
+---
+
+## 2-9. フロントエンド — Axios クライアント
+
+### `src/api/client.ts`
+
+```typescript
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: '/api/v1',  // Vite proxy 経由
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  },
+});
+
+// リクエストインターセプター: トークン付与
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('auth_token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// レスポンスインターセプター: 401 でトークン削除 + リダイレクト
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('auth_token');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;
+```
+
+### `src/api/auth.ts`
+
+```typescript
+import apiClient from './client';
+
+export const register = (data: RegisterData) =>
+  apiClient.post('/auth/register', data);
+
+export const login = (data: LoginData) =>
+  apiClient.post('/auth/login', data);
+
+export const logout = () =>
+  apiClient.post('/auth/logout');
+
+export const getUser = () =>
+  apiClient.get('/auth/user');
+```
+
+### 設計判断: トークン保存場所
+
+| 方式 | メリット | デメリット |
+|---|---|---|
+| `localStorage` | 実装がシンプル、リロードで消えない | XSS 脆弱性でトークン漏洩のリスク |
+| `httpOnly Cookie` | XSS でアクセス不可 | CSRF 対策が必要、Sanctum SPA 認証が前提 |
+| メモリ (React state) | XSS でもアクセス困難 | リロードで消える |
+
+→ **`localStorage` を採用**。理由:
+- トークンベース認証（2-1 で決定済み）との整合性
+- 個人開発アプリでユーザー入力由来の HTML レンダリングが少なく XSS リスクが低い
+- リロード時の UX を優先
+
+---
+
+## 2-10. フロントエンド — AuthContext + useAuth
+
+### `src/hooks/useAuth.tsx`
+
+```typescript
+interface AuthContextType {
+  user: User | null;
+  isLoading: boolean;
+  login: (data: LoginData) => Promise<void>;
+  register: (data: RegisterData) => Promise<void>;
+  logout: () => Promise<void>;
+}
+```
+
+**処理フロー**:
+1. アプリ起動時に `localStorage` にトークンがあれば `getUser()` を呼んでユーザー情報を復元
+2. `login` / `register` 成功時にトークンを `localStorage` に保存し、`user` state を更新
+3. `logout` 成功時にトークンを削除し、`user` state を `null` に
+
+### `src/components/ProtectedRoute.tsx`
+
+```typescript
+const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) return <LoadingSpinner />;
+  if (!user) return <Navigate to="/login" replace />;
+
+  return <>{children}</>;
+};
+```
+
+---
+
+## 2-11. フロントエンド — ページコンポーネント
+
+### ルーティング構成
+
+```typescript
+<Routes>
+  {/* 公開ルート */}
+  <Route path="/login" element={<LoginPage />} />
+  <Route path="/register" element={<RegisterPage />} />
+
+  {/* 保護ルート */}
+  <Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+    <Route path="/" element={<DashboardPage />} />
+    {/* Step 3 以降で追加 */}
+  </Route>
+</Routes>
+```
+
+### LoginPage
+
+- React Hook Form でフォーム管理
+- フィールド: `email`, `password`
+- エラー表示: バリデーションエラー、認証エラー
+- 登録ページへのリンク
+- ログイン成功時に `/` へリダイレクト
+
+### RegisterPage
+
+- フィールド: `name`, `email`, `password`, `password_confirmation`
+- エラー表示: バリデーションエラー（email 重複含む）
+- ログインページへのリンク
+- 登録成功時に `/` へリダイレクト
+
+### AppLayout + Header
+
+- `Header`: ユーザー名表示、ログアウトボタン
+- `Outlet` で子ルートを描画
+- ログアウト時に `/login` へリダイレクト
+
+### DashboardPage（仮）
+
+- Step 2 時点では「ログイン済みです」程度のプレースホルダー
+- Step 3 以降で家族・本棚情報を表示
+
+---
+
+## 2-12. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | ユーザー登録 API | `curl -X POST .../auth/register` | 201 + token |
+| 2 | ログイン API | `curl -X POST .../auth/login` | 200 + token |
+| 3 | ユーザー情報取得 | `curl -H "Authorization: Bearer {token}" .../auth/user` | 200 + user |
+| 4 | 未認証アクセス | `curl .../auth/user` (トークンなし) | 401 |
+| 5 | ログアウト API | `curl -X POST -H "Authorization: Bearer {token}" .../auth/logout` | 200 |
+| 6 | ログアウト後アクセス | 同じトークンで `/auth/user` | 401 |
+| 7 | React 登録フロー | ブラウザで `/register` → フォーム入力 → 送信 | ダッシュボードに遷移 |
+| 8 | React ログインフロー | ブラウザで `/login` → フォーム入力 → 送信 | ダッシュボードに遷移 |
+| 9 | React ログアウト | Header のログアウトボタン | ログインページに遷移 |
+| 10 | 保護ルート | 未ログインで `/` にアクセス | `/login` にリダイレクト |
+| 11 | リロード後のセッション維持 | ログイン後にブラウザリロード | ユーザー情報が復元され、ログイン状態が維持される |
+| 12 | Feature テスト | `task test` | 全テスト通過 |
+
+---
+
+## 作業順序まとめ
+
+```
+2-1.  Sanctum セットアップ (composer, config, migrate)
+         ↓
+2-2.  Domain 層 (Entity, ValueObject, RepositoryInterface)
+         ↓
+2-3.  Application 層 (Command/Query Handler)
+         ↓
+2-4.  Infrastructure 層 (EloquentUserRepository, ServiceProvider バインド)
+         ↓
+2-5.  Interface 層 (Controller, Request, Resource, Routes)
+         ↓
+2-6.  Eloquent Model 調整 (HasApiTokens)
+         ↓
+2-7.  Feature テスト作成・実行
+         ↓
+2-8.  フロントエンド パッケージ追加
+         ↓
+2-9.  Axios クライアント (client.ts, auth.ts)
+         ↓
+2-10. AuthContext + useAuth + ProtectedRoute
+         ↓
+2-11. ページコンポーネント (Login, Register, AppLayout, Dashboard)
+         ↓
+2-12. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **Sanctum の認証方式**: トークンベース（Bearer トークン）を採用。本番で FE/BE が異なるドメインになるため
+- **Domain 層の純粋性 vs 実用性**: トークン生成は Sanctum 依存のため Handler 内で Eloquent Model 経由で呼ぶ。過度な抽象化は避ける
+- **Eloquent Model の配置**: Step 2 では `app/Models/` のまま。移動は必要性が出てから判断
+- **TanStack Query**: Step 2 では未導入。Axios + useEffect でシンプルに実装し、Step 3 以降で導入
+- **パスワードリセット**: Phase 1 のスコープ外。必要になった時点で追加
+- **メール認証**: Phase 1 のスコープ外。Mailpit は Step 6（招待機能）で活用
+- **エラーハンドリング**: Laravel デフォルトの例外ハンドリングをベースに、API 用の JSON レスポンスが返ることを確認。カスタム例外は必要に応じて追加

--- a/docs/plans/step3-family.md
+++ b/docs/plans/step3-family.md
@@ -1,0 +1,954 @@
+# Step 3: 家族管理 (Family) — 詳細プラン
+
+## ゴール
+
+家族の作成・編集、子どもの登録・編集・削除、家族メンバー一覧の取得ができる状態にする。
+Family コンテキストを DDD + Clean Architecture + CQRS の構成で実装し、ログイン後に家族未所属のユーザーには家族作成を促す導線を用意する。
+
+## 完了条件
+
+- [ ] `POST /api/v1/families` で家族を作成でき、作成者が自動的にメンバーになる
+- [ ] `GET /api/v1/families/{family}` で家族情報を取得できる
+- [ ] `PUT /api/v1/families/{family}` で家族名を編集できる
+- [ ] `GET /api/v1/families/{family}/members` で家族メンバー一覧を取得できる
+- [ ] `GET /api/v1/families/{family}/children` で子ども一覧を取得できる
+- [ ] `POST /api/v1/families/{family}/children` で子どもを登録できる
+- [ ] `PUT /api/v1/families/{family}/children/{child}` で子ども情報を編集できる
+- [ ] `DELETE /api/v1/families/{family}/children/{child}` で子どもを削除できる
+- [ ] 家族に所属していないユーザーが他家族のリソースにアクセスすると 403 が返る
+- [ ] React SPA から家族作成・子ども管理の一連のフローが動作する
+- [ ] ログイン後に家族未所属のユーザーには家族作成画面が表示される
+- [ ] Feature テストが全て通る
+
+---
+
+## 3-1. マイグレーション
+
+### 作成するマイグレーション
+
+#### `create_families_table`
+
+```php
+Schema::create('families', function (Blueprint $table) {
+    $table->id();
+    $table->string('name');
+    $table->timestamps();
+});
+```
+
+#### `add_family_id_to_users_table`
+
+```php
+Schema::table('users', function (Blueprint $table) {
+    $table->foreignId('family_id')->nullable()->after('id')->constrained()->nullOnDelete();
+});
+```
+
+#### `create_children_table`
+
+```php
+Schema::create('children', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('family_id')->constrained()->cascadeOnDelete();
+    $table->string('name');
+    $table->date('birthday')->nullable();
+    $table->timestamps();
+});
+```
+
+### 設計判断: users.family_id の nullable
+
+- ユーザー登録時点では家族未所属（`family_id = null`）
+- 家族作成 or 招待受理で `family_id` が設定される
+- `nullOnDelete`: 家族が削除された場合、ユーザーは未所属状態に戻る（ユーザー自体は削除しない）
+
+### 設計判断: ユーザーと家族の関係（1対1 vs 多対多）
+
+| 方式 | 構造 | メリット | デメリット |
+|---|---|---|---|
+| 1対1（`users.family_id`） | ユーザーは 1 つの家族にのみ所属 | シンプル、クエリが簡単 | 複数家族への所属不可 |
+| 多対多（中間テーブル） | `family_user` ピボットテーブル | 柔軟、ロール管理も可能 | 複雑、現時点で不要 |
+
+→ **1対1 を採用**。理由:
+- 絵本読み聞かせアプリにおいて、ユーザーが複数家族に所属するユースケースが Phase 1 では想定されない
+- rebuild-plan の DB スキーマ設計（`users.family_id`）に準拠
+- 必要になった時点で中間テーブルへの移行は可能
+
+### 確認ポイント
+
+- `task migrate` で 3 つのマイグレーションが成功する
+- `users` テーブルに `family_id` カラムが追加される
+
+---
+
+## 3-2. Family コンテキスト — Domain 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Family/
+├── Domain/
+│   ├── Entity/
+│   │   ├── Family.php
+│   │   └── Child.php
+│   ├── ValueObject/
+│   │   ├── FamilyId.php
+│   │   ├── FamilyName.php
+│   │   ├── ChildId.php
+│   │   ├── ChildName.php
+│   │   └── Birthday.php
+│   └── Repository/
+│       ├── FamilyRepositoryInterface.php
+│       └── ChildRepositoryInterface.php
+```
+
+### Domain Entity: `Family`
+
+```php
+namespace Packages\Family\Domain\Entity;
+
+final class Family
+{
+    public function __construct(
+        private readonly ?FamilyId $id,
+        private FamilyName $name,
+    ) {}
+
+    public static function create(FamilyName $name): self
+    {
+        return new self(null, $name);
+    }
+
+    public static function reconstruct(FamilyId $id, FamilyName $name): self
+    {
+        return new self($id, $name);
+    }
+
+    public function rename(FamilyName $name): void
+    {
+        $this->name = $name;
+    }
+
+    // Getter メソッド
+}
+```
+
+### Domain Entity: `Child`
+
+```php
+namespace Packages\Family\Domain\Entity;
+
+final class Child
+{
+    public function __construct(
+        private readonly ?ChildId $id,
+        private readonly FamilyId $familyId,
+        private ChildName $name,
+        private ?Birthday $birthday,
+    ) {}
+
+    public static function create(
+        FamilyId $familyId,
+        ChildName $name,
+        ?Birthday $birthday,
+    ): self {
+        return new self(null, $familyId, $name, $birthday);
+    }
+
+    public function update(ChildName $name, ?Birthday $birthday): void
+    {
+        $this->name = $name;
+        $this->birthday = $birthday;
+    }
+
+    // Getter, reconstruct メソッド
+}
+```
+
+### Value Objects
+
+| クラス | バリデーション |
+|---|---|
+| `FamilyId` | 正の整数 |
+| `FamilyName` | 1〜255文字 |
+| `ChildId` | 正の整数 |
+| `ChildName` | 1〜255文字 |
+| `Birthday` | 過去の日付であること（未来日を拒否） |
+
+### Repository Interfaces
+
+**`FamilyRepositoryInterface`**:
+```php
+interface FamilyRepositoryInterface
+{
+    public function findById(FamilyId $id): ?Family;
+    public function save(Family $family): Family;
+}
+```
+
+**`ChildRepositoryInterface`**:
+```php
+interface ChildRepositoryInterface
+{
+    public function findById(ChildId $id): ?Child;
+    public function findByFamilyId(FamilyId $familyId): array;
+    public function save(Child $child): Child;
+    public function delete(ChildId $id): void;
+}
+```
+
+---
+
+## 3-3. Family コンテキスト — Application 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Family/
+├── Application/
+│   ├── Command/
+│   │   ├── CreateFamily/
+│   │   │   ├── CreateFamilyCommand.php
+│   │   │   └── CreateFamilyHandler.php
+│   │   ├── UpdateFamily/
+│   │   │   ├── UpdateFamilyCommand.php
+│   │   │   └── UpdateFamilyHandler.php
+│   │   ├── AddChild/
+│   │   │   ├── AddChildCommand.php
+│   │   │   └── AddChildHandler.php
+│   │   ├── UpdateChild/
+│   │   │   ├── UpdateChildCommand.php
+│   │   │   └── UpdateChildHandler.php
+│   │   └── RemoveChild/
+│   │       ├── RemoveChildCommand.php
+│   │       └── RemoveChildHandler.php
+│   └── Query/
+│       ├── GetFamily/
+│       │   ├── GetFamilyQuery.php
+│       │   └── GetFamilyHandler.php
+│       ├── ListMembers/
+│       │   ├── ListMembersQuery.php
+│       │   └── ListMembersHandler.php
+│       └── ListChildren/
+│           ├── ListChildrenQuery.php
+│           └── ListChildrenHandler.php
+```
+
+### CreateFamily
+
+**`CreateFamilyCommand`** (DTO):
+```php
+final class CreateFamilyCommand
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $userId,  // 作成者
+    ) {}
+}
+```
+
+**`CreateFamilyHandler`**:
+1. `Family::create()` でエンティティ生成
+2. `FamilyRepository::save()` で永続化
+3. 作成者の `family_id` を更新（User の所属を設定）
+4. 作成された Family を返却
+
+### UpdateFamily
+
+**`UpdateFamilyHandler`**:
+1. `FamilyRepository::findById()` で取得
+2. `Family::rename()` で名前更新
+3. `FamilyRepository::save()` で永続化
+
+### AddChild
+
+**`AddChildHandler`**:
+1. `Child::create()` でエンティティ生成
+2. `ChildRepository::save()` で永続化
+
+### UpdateChild
+
+**`UpdateChildHandler`**:
+1. `ChildRepository::findById()` で取得
+2. `Child::update()` で更新
+3. `ChildRepository::save()` で永続化
+
+### RemoveChild
+
+**`RemoveChildHandler`**:
+1. `ChildRepository::delete()` で削除
+
+### Query ハンドラ（CQRS Query 側）
+
+Query ハンドラは Eloquent を直接使い、Domain 層を経由しない:
+
+- **GetFamilyHandler**: `Family::find($id)` → DTO or Eloquent Model
+- **ListMembersHandler**: `User::where('family_id', $id)->get()` → Collection
+- **ListChildrenHandler**: `Child::where('family_id', $id)->get()` → Collection
+
+### 設計判断: CreateFamily 時の User.family_id 更新
+
+家族作成時に作成者を自動的にメンバーにする必要がある。これは Family コンテキストから Auth コンテキスト（User）を更新するコンテキスト横断の操作。
+
+| 方式 | 説明 |
+|---|---|
+| Handler 内で直接 User を更新 | シンプルだが、コンテキスト間の結合が生まれる |
+| ドメインイベント発行 | 疎結合だが、Phase 1 では過剰 |
+
+→ **Handler 内で直接更新を採用**。Eloquent Model 経由で `$user->update(['family_id' => $family->id()])` を呼ぶ。コンテキスト間の依存は意識しつつ、Phase 1 ではシンプルさを優先する。
+
+---
+
+## 3-4. Family コンテキスト — Infrastructure 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Family/
+└── Infrastructure/
+    └── Repository/
+        ├── EloquentFamilyRepository.php
+        └── EloquentChildRepository.php
+```
+
+### EloquentFamilyRepository
+
+```php
+namespace Packages\Family\Infrastructure\Repository;
+
+use App\Models\Family as EloquentFamily;
+use Packages\Family\Domain\Entity\Family;
+use Packages\Family\Domain\Repository\FamilyRepositoryInterface;
+
+final class EloquentFamilyRepository implements FamilyRepositoryInterface
+{
+    public function findById(FamilyId $id): ?Family
+    {
+        $model = EloquentFamily::find($id->value());
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function save(Family $family): Family
+    {
+        if ($family->id() === null) {
+            $model = EloquentFamily::create(['name' => $family->name()->value()]);
+        } else {
+            $model = EloquentFamily::findOrFail($family->id()->value());
+            $model->update(['name' => $family->name()->value()]);
+        }
+        return $this->toDomainEntity($model);
+    }
+
+    private function toDomainEntity(EloquentFamily $model): Family
+    {
+        return Family::reconstruct(
+            new FamilyId($model->id),
+            new FamilyName($model->name),
+        );
+    }
+}
+```
+
+### EloquentChildRepository
+
+同様のパターンで実装。`save` は ID の有無で create / update を切り替え。
+
+### ServiceProvider でのバインド
+
+```php
+// AppServiceProvider または FamilyServiceProvider
+$this->app->bind(FamilyRepositoryInterface::class, EloquentFamilyRepository::class);
+$this->app->bind(ChildRepositoryInterface::class, EloquentChildRepository::class);
+```
+
+---
+
+## 3-5. Eloquent Model
+
+### `app/Models/Family.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Family extends Model
+{
+    protected $fillable = ['name'];
+
+    public function members(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Child::class);
+    }
+}
+```
+
+### `app/Models/Child.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Child extends Model
+{
+    protected $fillable = ['family_id', 'name', 'birthday'];
+
+    protected $casts = [
+        'birthday' => 'date',
+    ];
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(Family::class);
+    }
+}
+```
+
+### `app/Models/User.php`（リレーション追加）
+
+```php
+// 既存の User モデルに追加
+public function family(): BelongsTo
+{
+    return $this->belongsTo(Family::class);
+}
+```
+
+---
+
+## 3-6. Interface 層 — Controller, Request, Resource, Routes
+
+### ディレクトリ構成
+
+```
+backend/app/Http/
+├── Controllers/Api/
+│   ├── FamilyController.php
+│   └── ChildController.php
+├── Requests/
+│   ├── StoreFamilyRequest.php
+│   ├── UpdateFamilyRequest.php
+│   ├── StoreChildRequest.php
+│   └── UpdateChildRequest.php
+└── Resources/
+    ├── FamilyResource.php
+    ├── MemberResource.php
+    └── ChildResource.php
+```
+
+### FamilyController
+
+```php
+class FamilyController extends Controller
+{
+    // POST /api/v1/families
+    public function store(StoreFamilyRequest $request, CreateFamilyHandler $handler)
+
+    // GET /api/v1/families/{family}
+    public function show(Family $family, GetFamilyHandler $handler)
+
+    // PUT /api/v1/families/{family}
+    public function update(UpdateFamilyRequest $request, Family $family, UpdateFamilyHandler $handler)
+
+    // GET /api/v1/families/{family}/members
+    public function members(Family $family, ListMembersHandler $handler)
+}
+```
+
+### ChildController
+
+```php
+class ChildController extends Controller
+{
+    // GET /api/v1/families/{family}/children
+    public function index(Family $family, ListChildrenHandler $handler)
+
+    // POST /api/v1/families/{family}/children
+    public function store(StoreChildRequest $request, Family $family, AddChildHandler $handler)
+
+    // PUT /api/v1/families/{family}/children/{child}
+    public function update(UpdateChildRequest $request, Family $family, Child $child, UpdateChildHandler $handler)
+
+    // DELETE /api/v1/families/{family}/children/{child}
+    public function destroy(Family $family, Child $child, RemoveChildHandler $handler)
+}
+```
+
+### FormRequest バリデーション
+
+**`StoreFamilyRequest`** / **`UpdateFamilyRequest`**:
+| フィールド | ルール |
+|---|---|
+| `name` | `required`, `string`, `max:255` |
+
+**`StoreChildRequest`** / **`UpdateChildRequest`**:
+| フィールド | ルール |
+|---|---|
+| `name` | `required`, `string`, `max:255` |
+| `birthday` | `nullable`, `date`, `before_or_equal:today` |
+
+### API Resource
+
+**`FamilyResource`**:
+```json
+{
+  "id": 1,
+  "name": "山田家",
+  "created_at": "2026-03-08T00:00:00.000000Z"
+}
+```
+
+**`MemberResource`**:
+```json
+{
+  "id": 1,
+  "name": "太郎",
+  "email": "taro@example.com"
+}
+```
+
+**`ChildResource`**:
+```json
+{
+  "id": 1,
+  "name": "はなこ",
+  "birthday": "2022-05-15",
+  "age": 3
+}
+```
+
+> `age` は `birthday` から算出する Accessor（Eloquent Model 側で計算 or Resource 内で計算）
+
+### ルート定義 (`routes/api.php`)
+
+```php
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    // Family
+    Route::post('/families', [FamilyController::class, 'store']);
+    Route::get('/families/{family}', [FamilyController::class, 'show']);
+    Route::put('/families/{family}', [FamilyController::class, 'update']);
+    Route::get('/families/{family}/members', [FamilyController::class, 'members']);
+
+    // Children
+    Route::get('/families/{family}/children', [ChildController::class, 'index']);
+    Route::post('/families/{family}/children', [ChildController::class, 'store']);
+    Route::put('/families/{family}/children/{child}', [ChildController::class, 'update']);
+    Route::delete('/families/{family}/children/{child}', [ChildController::class, 'destroy']);
+});
+```
+
+全エンドポイントに `auth:sanctum` ミドルウェアを適用。
+
+---
+
+## 3-7. 認可 — FamilyPolicy
+
+### 認可ロジック
+
+ユーザーが指定された家族に所属しているかを検証する Policy:
+
+```php
+namespace App\Policies;
+
+class FamilyPolicy
+{
+    // 家族に所属しているか
+    public function view(User $user, Family $family): bool
+    {
+        return $user->family_id === $family->id;
+    }
+
+    // 家族情報を更新できるか（所属 = 更新可能）
+    public function update(User $user, Family $family): bool
+    {
+        return $user->family_id === $family->id;
+    }
+}
+```
+
+### ChildPolicy
+
+子どもが指定された家族に属しているか + ユーザーがその家族のメンバーか:
+
+```php
+class ChildPolicy
+{
+    public function manage(User $user, Child $child): bool
+    {
+        return $user->family_id === $child->family_id;
+    }
+}
+```
+
+### Controller での適用
+
+```php
+// FamilyController
+public function show(Family $family)
+{
+    $this->authorize('view', $family);
+    // ...
+}
+```
+
+### 設計判断: ロール（role）による権限分離
+
+`users.role`, `users.avatar_path` は Phase 1 のスキーマから除外済み（rebuild-plan 参照）。Phase 1 では:
+- ロールによる権限差は設けない（全メンバーが等しく操作可能）
+- 将来的に「管理者のみ家族削除可能」等の権限が必要になった時点で `role` カラムを導入
+
+---
+
+## 3-8. Feature テスト
+
+### テストファイル
+
+```
+backend/tests/Feature/
+└── Family/
+    ├── CreateFamilyTest.php
+    ├── UpdateFamilyTest.php
+    ├── GetFamilyTest.php
+    ├── ListMembersTest.php
+    ├── AddChildTest.php
+    ├── UpdateChildTest.php
+    └── RemoveChildTest.php
+```
+
+### テストケース一覧
+
+**CreateFamilyTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に家族を作成 | 201, 作成者の family_id が設定される |
+| 2 | 未認証でアクセス | 401 |
+| 3 | name が空 | 422 |
+| 4 | すでに家族に所属しているユーザーが作成 | 422 or 403（要検討） |
+
+**UpdateFamilyTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に家族名を更新 | 200 |
+| 2 | 所属していない家族を更新 | 403 |
+| 3 | name が空 | 422 |
+
+**GetFamilyTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 所属する家族の情報取得 | 200, 家族情報が返る |
+| 2 | 所属していない家族の情報取得 | 403 |
+
+**ListMembersTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 家族メンバー一覧取得 | 200, メンバーリスト |
+| 2 | 所属していない家族のメンバー取得 | 403 |
+
+**AddChildTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に子どもを登録 | 201 |
+| 2 | birthday が未来日 | 422 |
+| 3 | 所属していない家族に追加 | 403 |
+
+**UpdateChildTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に子ども情報を更新 | 200 |
+| 2 | 他家族の子どもを更新 | 403 |
+
+**RemoveChildTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に子どもを削除 | 200 or 204 |
+| 2 | 他家族の子どもを削除 | 403 |
+
+---
+
+## 3-9. フロントエンド — 追加パッケージ
+
+### インストール
+
+```bash
+docker compose exec frontend npm install @tanstack/react-query
+```
+
+| パッケージ | 用途 |
+|---|---|
+| `@tanstack/react-query` | サーバー状態管理、キャッシュ、自動再取得 |
+
+### TanStack Query 初期セットアップ
+
+`src/main.tsx` に `QueryClientProvider` を追加:
+
+```typescript
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5 * 60 * 1000,  // 5分
+    },
+  },
+});
+
+// <QueryClientProvider client={queryClient}> で App をラップ
+```
+
+---
+
+## 3-10. フロントエンド — API 関数
+
+### `src/api/family.ts`
+
+```typescript
+import apiClient from './client';
+
+export const createFamily = (data: { name: string }) =>
+  apiClient.post('/families', data);
+
+export const getFamily = (familyId: number) =>
+  apiClient.get(`/families/${familyId}`);
+
+export const updateFamily = (familyId: number, data: { name: string }) =>
+  apiClient.put(`/families/${familyId}`, data);
+
+export const getMembers = (familyId: number) =>
+  apiClient.get(`/families/${familyId}/members`);
+
+export const getChildren = (familyId: number) =>
+  apiClient.get(`/families/${familyId}/children`);
+
+export const addChild = (familyId: number, data: { name: string; birthday?: string }) =>
+  apiClient.post(`/families/${familyId}/children`, data);
+
+export const updateChild = (familyId: number, childId: number, data: { name: string; birthday?: string }) =>
+  apiClient.put(`/families/${familyId}/children/${childId}`, data);
+
+export const removeChild = (familyId: number, childId: number) =>
+  apiClient.delete(`/families/${familyId}/children/${childId}`);
+```
+
+---
+
+## 3-11. フロントエンド — カスタムフック
+
+### `src/hooks/useFamily.ts`
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useFamily = (familyId: number) => {
+  return useQuery({
+    queryKey: ['family', familyId],
+    queryFn: () => getFamily(familyId),
+  });
+};
+
+export const useCreateFamily = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createFamily,
+    onSuccess: () => {
+      // AuthContext の user 情報を再取得（family_id が更新されるため）
+    },
+  });
+};
+
+export const useUpdateFamily = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string }) => updateFamily(familyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['family', familyId] });
+    },
+  });
+};
+```
+
+### `src/hooks/useChildren.ts`
+
+```typescript
+export const useChildren = (familyId: number) => {
+  return useQuery({
+    queryKey: ['children', familyId],
+    queryFn: () => getChildren(familyId),
+  });
+};
+
+export const useAddChild = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; birthday?: string }) => addChild(familyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['children', familyId] });
+    },
+  });
+};
+
+// useUpdateChild, useRemoveChild も同様のパターン
+```
+
+---
+
+## 3-12. フロントエンド — ページコンポーネント
+
+### ルーティング構成（Step 2 からの追加）
+
+```typescript
+<Routes>
+  {/* 公開ルート */}
+  <Route path="/login" element={<LoginPage />} />
+  <Route path="/register" element={<RegisterPage />} />
+
+  {/* 保護ルート */}
+  <Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+    <Route path="/" element={<DashboardPage />} />
+    <Route path="/family/create" element={<CreateFamilyPage />} />
+    <Route path="/family/settings" element={<FamilySettingsPage />} />
+  </Route>
+</Routes>
+```
+
+### 家族未所属時の導線
+
+ログイン後のフロー:
+
+```
+ログイン → user.family_id をチェック
+  ├─ family_id あり → DashboardPage（通常表示）
+  └─ family_id なし → CreateFamilyPage にリダイレクト
+```
+
+実装方法: `ProtectedRoute` 内で `user.family_id` を確認し、未設定なら `/family/create` へリダイレクト。ただし `/family/create` 自身ではリダイレクトしない（無限ループ防止）。
+
+### CreateFamilyPage
+
+- 家族名入力フォーム（React Hook Form）
+- 作成成功後にダッシュボードへリダイレクト
+- AuthContext の user 情報を再取得（family_id を反映）
+
+### FamilySettingsPage
+
+- 家族名の編集フォーム
+- メンバー一覧表示
+- 子ども管理セクション:
+  - 子どもリスト（`ChildCard` コンポーネント）
+  - 子ども追加フォーム（`ChildForm` コンポーネント）
+  - 各子どもの編集・削除
+
+### ChildCard コンポーネント
+
+- 子どもの名前、年齢（birthday から算出）を表示
+- 編集ボタン → インラインフォームまたはモーダル
+- 削除ボタン → 確認ダイアログ後に削除
+
+### ChildForm コンポーネント
+
+- フィールド: `name`（必須）, `birthday`（任意）
+- React Hook Form でバリデーション
+- 追加 / 編集 の両方で再利用
+
+### DashboardPage（更新）
+
+Step 2 のプレースホルダーから拡張:
+- 家族名を表示
+- 子ども一覧を簡易表示
+- 家族設定ページへのリンク
+- Step 4 以降で本棚・記録の情報を追加予定
+
+---
+
+## 3-13. UserResource の拡張
+
+Step 2 で作成した `UserResource` に `family_id` を追加:
+
+```php
+public function toArray($request): array
+{
+    return [
+        'id' => $this->id,
+        'name' => $this->name,
+        'email' => $this->email,
+        'family_id' => $this->family_id,
+        'created_at' => $this->created_at->toISOString(),
+    ];
+}
+```
+
+フロントエンドで `user.family_id` の有無により家族未所属判定を行うため。
+
+---
+
+## 3-14. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | マイグレーション | `task migrate` | families, children テーブル作成 + users.family_id 追加 |
+| 2 | 家族作成 API | `curl -X POST .../families` | 201, 作成者の family_id が設定 |
+| 3 | 家族情報取得 | `curl .../families/{id}` | 200, 家族情報 |
+| 4 | 家族名更新 | `curl -X PUT .../families/{id}` | 200 |
+| 5 | メンバー一覧 | `curl .../families/{id}/members` | 200, メンバーリスト |
+| 6 | 子ども一覧 | `curl .../families/{id}/children` | 200, 子どもリスト |
+| 7 | 子ども登録 | `curl -X POST .../families/{id}/children` | 201 |
+| 7 | 子ども更新 | `curl -X PUT .../families/{id}/children/{childId}` | 200 |
+| 8 | 子ども削除 | `curl -X DELETE .../families/{id}/children/{childId}` | 200 or 204 |
+| 10 | 認可: 他家族へのアクセス | 所属していない family_id でアクセス | 403 |
+| 11 | 既所属ユーザーの家族作成 | 既に家族に所属しているユーザーで POST /families | 403 or 422 |
+| 12 | React 家族作成フロー | 未所属ユーザーでログイン → 家族作成ページ表示 → 作成 | ダッシュボードに遷移 |
+| 13 | React 子ども管理 | 家族設定ページで追加・編集・削除 | 各操作が反映される |
+| 14 | Feature テスト | `task test` | 全テスト通過 |
+
+---
+
+## 作業順序まとめ
+
+```
+3-1.  マイグレーション (families, users.family_id, children)
+         ↓
+3-2.  Domain 層 (Entity, ValueObject, RepositoryInterface)
+         ↓
+3-3.  Application 層 (Command/Query Handler)
+         ↓
+3-4.  Infrastructure 層 (EloquentRepository, ServiceProvider バインド)
+         ↓
+3-5.  Eloquent Model (Family, Child, User リレーション追加)
+         ↓
+3-6.  Interface 層 (Controller, Request, Resource, Routes)
+         ↓
+3-7.  認可 (FamilyPolicy, ChildPolicy)
+         ↓
+3-8.  Feature テスト作成・実行
+         ↓
+3-9.  フロントエンド TanStack Query セットアップ
+         ↓
+3-10. API 関数 (family.ts)
+         ↓
+3-11. カスタムフック (useFamily, useChildren)
+         ↓
+3-12. ページコンポーネント (CreateFamily, FamilySettings, Dashboard更新)
+         ↓
+3-13. UserResource 拡張 (family_id 追加)
+         ↓
+3-14. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **ユーザーと家族の関係**: 1対1（`users.family_id`）を採用。Phase 1 では複数家族所属のユースケースがない
+- **role カラム**: Step 3 では追加しない。認可は「家族に所属しているか」のみで判定
+- **すでに家族に所属しているユーザーの家族作成**: 403 を返す or バリデーションエラーとする。Phase 1 では家族脱退機能は提供しない
+- **CreateFamily 時の User 更新**: Handler 内で直接 Eloquent Model 経由で更新。ドメインイベントは Phase 1 では採用しない
+- **TanStack Query の導入**: Step 3 から導入。Step 2 の認証系フック（useAuth）は既存の useEffect ベースを維持し、Step 3 以降の CRUD 操作で TanStack Query を活用
+- **子ども削除時の影響**: Step 5 で `child_read_record` テーブルが追加された後は、子ども削除時に関連する読み聞かせ記録への影響を考慮する必要がある。Step 3 時点では単純削除で問題ない

--- a/docs/plans/step4-picture-books.md
+++ b/docs/plans/step4-picture-books.md
@@ -1,0 +1,1082 @@
+# Step 4: 絵本登録 (Picture Books) — 詳細プラン
+
+## ゴール
+
+Google Books API から絵本を検索し、家族の本棚に登録・管理できる状態にする。
+Bookshelf コンテキストを DDD + Clean Architecture + CQRS の構成で実装する。
+
+## 完了条件
+
+- [ ] `GET /api/v1/books/search?q={query}` で Google Books API の検索結果が返る
+- [ ] `POST /api/v1/families/{family}/books` で絵本を本棚に登録できる
+- [ ] `GET /api/v1/families/{family}/books` で本棚一覧がページネーション付きで取得できる
+- [ ] `GET /api/v1/families/{family}/books/{book}` で絵本詳細が取得できる
+- [ ] `PUT /api/v1/families/{family}/books/{book}` で評価・ステータス・レビューを更新できる
+- [ ] `DELETE /api/v1/families/{family}/books/{book}` で絵本を本棚から削除できる
+- [ ] 他家族の本棚にアクセスすると 403 が返る
+- [ ] React SPA から絵本検索・登録・本棚管理の一連のフローが動作する
+- [ ] Feature テストが全て通る
+
+---
+
+## 4-1. マイグレーション
+
+### `create_picture_books_table`
+
+```php
+Schema::create('picture_books', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('family_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('registered_by')->constrained('users')->nullOnDelete();
+    $table->string('google_books_id')->nullable();
+    $table->string('isbn')->nullable();
+    $table->string('title');
+    $table->json('authors');              // ["著者A", "著者B"]
+    $table->string('thumbnail_url')->nullable();
+    $table->unsignedTinyInteger('rating')->nullable();  // 1-5
+    $table->string('read_status')->default('unread');    // unread, reading, read
+    $table->text('review')->nullable();
+    $table->timestamps();
+
+    $table->index(['family_id', 'read_status']);
+    $table->index(['family_id', 'created_at']);
+});
+```
+
+### 設計判断: authors を JSON 型にする理由
+
+| 方式 | 構造 | メリット | デメリット |
+|---|---|---|---|
+| JSON カラム | `authors JSON` | シンプル、Google Books API の配列をそのまま保存 | 著者での検索が非効率 |
+| 正規化（中間テーブル） | `authors` + `author_picture_book` | 著者マスタで検索・集計可能 | 設計が複雑、API レスポンスからの変換が必要 |
+
+→ **JSON 型を採用**。理由:
+- Google Books API が `authors: ["著者A", "著者B"]` の配列で返すため、変換なしで保存できる
+- 本アプリで著者別検索・集計の要件がない（絵本タイトルや読み聞かせ記録が主な関心事）
+- MySQL 8.0 の JSON 関数で必要に応じてクエリ可能
+
+### 設計判断: read_status の型
+
+| 方式 | 説明 |
+|---|---|
+| ENUM | DB レベルで値を制約。マイグレーションなしに値の追加不可 |
+| string + アプリバリデーション | 柔軟、マイグレーション不要で値追加可能 |
+
+→ **string + Value Object で制約** を採用。Domain 層の Value Object で有効な値を管理し、DB は string で保存。
+
+### 設計判断: google_books_id と isbn の nullable
+
+- Google Books API の検索結果から登録する場合は `google_books_id` が設定される
+- 手動登録（Google Books にない絵本）も許容するため、両方 nullable
+- 重複チェック: `family_id` + `google_books_id` の組み合わせで既登録を判定（同じ本を同家族で2回登録しない）
+
+### 確認ポイント
+
+- `task migrate` で `picture_books` テーブルが作成される
+
+---
+
+## 4-2. Bookshelf コンテキスト — Domain 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Bookshelf/
+├── Domain/
+│   ├── Entity/
+│   │   └── PictureBook.php
+│   ├── ValueObject/
+│   │   ├── Isbn.php
+│   │   ├── BookTitle.php
+│   │   ├── Authors.php
+│   │   ├── Rating.php
+│   │   └── ReadStatus.php
+│   └── Repository/
+│       └── PictureBookRepositoryInterface.php
+```
+
+> `PictureBookId`, `FamilyId`, `UserId` は共有カーネル（`packages/Shared/ValueObject/`）に定義。詳細は rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照。
+
+### Domain Entity: `PictureBook`
+
+```php
+namespace Packages\Bookshelf\Domain\Entity;
+
+final class PictureBook
+{
+    public function __construct(
+        private readonly ?PictureBookId $id,
+        private readonly FamilyId $familyId,
+        private readonly UserId $registeredBy,
+        private readonly ?string $googleBooksId,
+        private readonly ?Isbn $isbn,
+        private readonly BookTitle $title,
+        private readonly Authors $authors,
+        private readonly ?string $thumbnailUrl,
+        private ?Rating $rating,
+        private ReadStatus $readStatus,
+        private ?string $review,
+    ) {}
+
+    public static function register(
+        FamilyId $familyId,
+        UserId $registeredBy,
+        ?string $googleBooksId,
+        ?Isbn $isbn,
+        BookTitle $title,
+        Authors $authors,
+        ?string $thumbnailUrl,
+    ): self {
+        return new self(
+            id: null,
+            familyId: $familyId,
+            registeredBy: $registeredBy,
+            googleBooksId: $googleBooksId,
+            isbn: $isbn,
+            title: $title,
+            authors: $authors,
+            thumbnailUrl: $thumbnailUrl,
+            rating: null,
+            readStatus: ReadStatus::Unread,
+            review: null,
+        );
+    }
+
+    public function updateReview(?Rating $rating, ReadStatus $readStatus, ?string $review): void
+    {
+        $this->rating = $rating;
+        $this->readStatus = $readStatus;
+        $this->review = $review;
+    }
+
+    // Getter, reconstruct メソッド
+}
+```
+
+### Value Objects
+
+| クラス | 内容 |
+|---|---|
+| `PictureBookId` | 正の整数 |
+| `Isbn` | ISBN-10 or ISBN-13 の形式検証（ハイフンなし数字列） |
+| `BookTitle` | 1〜500文字 |
+| `Authors` | `string[]` のラッパー。空配列を許容（著者不明） |
+| `Rating` | 1〜5 の整数 |
+| `ReadStatus` | Enum: `Unread`, `Reading`, `Read` |
+
+### ReadStatus（Enum）
+
+```php
+namespace Packages\Bookshelf\Domain\ValueObject;
+
+enum ReadStatus: string
+{
+    case Unread = 'unread';
+    case Reading = 'reading';
+    case Read = 'read';
+}
+```
+
+### Repository Interface
+
+```php
+namespace Packages\Bookshelf\Domain\Repository;
+
+interface PictureBookRepositoryInterface
+{
+    public function findById(PictureBookId $id): ?PictureBook;
+    public function findByFamilyIdAndGoogleBooksId(FamilyId $familyId, string $googleBooksId): ?PictureBook;
+    public function save(PictureBook $book): PictureBook;
+    public function delete(PictureBookId $id): void;
+}
+```
+
+---
+
+## 4-3. Bookshelf コンテキスト — Application 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Bookshelf/
+├── Application/
+│   ├── Command/
+│   │   ├── AddBook/
+│   │   │   ├── AddBookCommand.php
+│   │   │   └── AddBookHandler.php
+│   │   ├── UpdateBook/
+│   │   │   ├── UpdateBookCommand.php
+│   │   │   └── UpdateBookHandler.php
+│   │   └── RemoveBook/
+│   │       ├── RemoveBookCommand.php
+│   │       └── RemoveBookHandler.php
+│   └── Query/
+│       ├── SearchGoogleBooks/
+│       │   ├── SearchGoogleBooksQuery.php
+│       │   └── SearchGoogleBooksHandler.php
+│       ├── ListBooks/
+│       │   ├── ListBooksQuery.php
+│       │   └── ListBooksHandler.php
+│       └── GetBook/
+│           ├── GetBookQuery.php
+│           └── GetBookHandler.php
+```
+
+### AddBook
+
+**`AddBookCommand`** (DTO):
+```php
+final class AddBookCommand
+{
+    public function __construct(
+        public readonly int $familyId,
+        public readonly int $userId,
+        public readonly ?string $googleBooksId,
+        public readonly ?string $isbn,
+        public readonly string $title,
+        public readonly array $authors,
+        public readonly ?string $thumbnailUrl,
+    ) {}
+}
+```
+
+**`AddBookHandler`**:
+1. `google_books_id` が指定されている場合、同家族で既に登録済みかチェック（重複防止）
+2. `PictureBook::register()` でエンティティ生成
+3. `PictureBookRepository::save()` で永続化
+4. 登録された PictureBook を返却
+
+### UpdateBook
+
+**`UpdateBookCommand`**:
+```php
+final class UpdateBookCommand
+{
+    public function __construct(
+        public readonly int $bookId,
+        public readonly ?int $rating,        // 1-5 or null
+        public readonly string $readStatus,  // unread, reading, read
+        public readonly ?string $review,
+    ) {}
+}
+```
+
+**`UpdateBookHandler`**:
+1. `PictureBookRepository::findById()` で取得
+2. `PictureBook::updateReview()` で更新
+3. `PictureBookRepository::save()` で永続化
+
+### RemoveBook
+
+**`RemoveBookHandler`**:
+1. `PictureBookRepository::delete()` で削除
+
+### SearchGoogleBooks（Query）
+
+**`SearchGoogleBooksQuery`**:
+```php
+final class SearchGoogleBooksQuery
+{
+    public function __construct(
+        public readonly string $keyword,
+        public readonly int $startIndex = 0,
+        public readonly int $maxResults = 20,
+    ) {}
+}
+```
+
+**`SearchGoogleBooksHandler`**:
+- Google Books API クライアントを呼び出し、結果を DTO に変換して返す
+- CQRS の Query 側だが、外部 API 呼び出しのため Domain 層は経由しない
+
+### ListBooks（Query）
+
+**`ListBooksHandler`**:
+- Eloquent を直接使って家族の本棚を取得
+- フィルター: `read_status`
+- ソート: `created_at` desc（デフォルト）
+- ページネーション: Laravel の `paginate()`
+
+### GetBook（Query）
+
+**`GetBookHandler`**:
+- Eloquent を直接使って絵本詳細を取得
+
+---
+
+## 4-4. Bookshelf コンテキスト — Infrastructure 層
+
+### ディレクトリ構成
+
+```
+backend/packages/Bookshelf/
+└── Infrastructure/
+    ├── Repository/
+    │   └── EloquentPictureBookRepository.php
+    └── External/
+        └── GoogleBooksApiClient.php
+```
+
+### EloquentPictureBookRepository
+
+```php
+namespace Packages\Bookshelf\Infrastructure\Repository;
+
+final class EloquentPictureBookRepository implements PictureBookRepositoryInterface
+{
+    public function findById(PictureBookId $id): ?PictureBook
+    {
+        $model = EloquentPictureBook::find($id->value());
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function findByFamilyIdAndGoogleBooksId(FamilyId $familyId, string $googleBooksId): ?PictureBook
+    {
+        $model = EloquentPictureBook::where('family_id', $familyId->value())
+            ->where('google_books_id', $googleBooksId)
+            ->first();
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function save(PictureBook $book): PictureBook
+    {
+        if ($book->id() === null) {
+            $model = EloquentPictureBook::create([
+                'family_id' => $book->familyId()->value(),
+                'registered_by' => $book->registeredBy()->value(),
+                'google_books_id' => $book->googleBooksId(),
+                'isbn' => $book->isbn()?->value(),
+                'title' => $book->title()->value(),
+                'authors' => $book->authors()->toArray(),
+                'thumbnail_url' => $book->thumbnailUrl(),
+                'rating' => $book->rating()?->value(),
+                'read_status' => $book->readStatus()->value,
+                'review' => $book->review(),
+            ]);
+        } else {
+            $model = EloquentPictureBook::findOrFail($book->id()->value());
+            $model->update([
+                'rating' => $book->rating()?->value(),
+                'read_status' => $book->readStatus()->value,
+                'review' => $book->review(),
+            ]);
+        }
+        return $this->toDomainEntity($model);
+    }
+
+    public function delete(PictureBookId $id): void
+    {
+        EloquentPictureBook::destroy($id->value());
+    }
+
+    private function toDomainEntity(EloquentPictureBook $model): PictureBook { /* ... */ }
+}
+```
+
+### GoogleBooksApiClient
+
+```php
+namespace Packages\Bookshelf\Infrastructure\External;
+
+use Illuminate\Support\Facades\Http;
+
+final class GoogleBooksApiClient
+{
+    private const BASE_URL = 'https://www.googleapis.com/books/v1/volumes';
+
+    public function search(string $keyword, int $startIndex = 0, int $maxResults = 20): array
+    {
+        $response = Http::get(self::BASE_URL, [
+            'q' => $keyword,
+            'startIndex' => $startIndex,
+            'maxResults' => $maxResults,
+            'langRestrict' => 'ja',
+            'printType' => 'books',
+        ]);
+
+        $response->throw();
+
+        return $this->transformResponse($response->json());
+    }
+
+    private function transformResponse(array $data): array
+    {
+        $totalItems = $data['totalItems'] ?? 0;
+        $items = array_map(fn (array $item) => $this->transformItem($item), $data['items'] ?? []);
+
+        return [
+            'total_items' => $totalItems,
+            'items' => $items,
+        ];
+    }
+
+    private function transformItem(array $item): array
+    {
+        $volumeInfo = $item['volumeInfo'] ?? [];
+        $isbn13 = $this->extractIsbn($volumeInfo['industryIdentifiers'] ?? [], 'ISBN_13');
+        $isbn10 = $this->extractIsbn($volumeInfo['industryIdentifiers'] ?? [], 'ISBN_10');
+
+        return [
+            'google_books_id' => $item['id'],
+            'title' => $volumeInfo['title'] ?? '',
+            'authors' => $volumeInfo['authors'] ?? [],
+            'isbn' => $isbn13 ?? $isbn10,
+            'thumbnail_url' => $volumeInfo['imageLinks']['thumbnail'] ?? null,
+            'published_date' => $volumeInfo['publishedDate'] ?? null,
+            'description' => $volumeInfo['description'] ?? null,
+            'page_count' => $volumeInfo['pageCount'] ?? null,
+        ];
+    }
+
+    private function extractIsbn(array $identifiers, string $type): ?string
+    {
+        foreach ($identifiers as $identifier) {
+            if ($identifier['type'] === $type) {
+                return $identifier['identifier'];
+            }
+        }
+        return null;
+    }
+}
+```
+
+### 設計判断: Google Books API キーの要否
+
+- Google Books API は API キーなしでもリクエスト可能（レート制限あり）
+- 個人開発アプリで利用量が少ないため、Phase 1 では API キーなしで開始
+- レート制限に引っかかった場合に API キーを設定する（`.env` に `GOOGLE_BOOKS_API_KEY` を追加）
+
+### 設計判断: サムネイル URL の扱い
+
+Google Books API が返す `thumbnail_url` は `http://` の場合がある。
+
+| 方式 | 説明 |
+|---|---|
+| そのまま保存 | シンプルだが mixed content 警告の可能性 |
+| `https://` に書き換えて保存 | Google Books は https でもアクセス可能 |
+| プロキシ経由で配信 | 確実だが実装コスト高 |
+
+→ **`https://` に書き換えて保存**。`GoogleBooksApiClient` 内で `str_replace('http://', 'https://', $url)` する。
+
+### ServiceProvider でのバインド
+
+```php
+$this->app->bind(PictureBookRepositoryInterface::class, EloquentPictureBookRepository::class);
+$this->app->bind(GoogleBooksApiClient::class, GoogleBooksApiClient::class);
+```
+
+---
+
+## 4-5. Eloquent Model
+
+### `app/Models/PictureBook.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PictureBook extends Model
+{
+    protected $fillable = [
+        'family_id',
+        'registered_by',
+        'google_books_id',
+        'isbn',
+        'title',
+        'authors',
+        'thumbnail_url',
+        'rating',
+        'read_status',
+        'review',
+    ];
+
+    protected $casts = [
+        'authors' => 'array',
+        'rating' => 'integer',
+    ];
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(Family::class);
+    }
+
+    public function registeredByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'registered_by');
+    }
+}
+```
+
+### `app/Models/Family.php`（リレーション追加）
+
+```php
+// 既存の Family モデルに追加
+public function pictureBooks(): HasMany
+{
+    return $this->hasMany(PictureBook::class);
+}
+```
+
+---
+
+## 4-6. Interface 層 — Controller, Request, Resource, Routes
+
+### ディレクトリ構成
+
+```
+backend/app/Http/
+├── Controllers/Api/
+│   └── PictureBookController.php
+├── Requests/
+│   ├── StoreBookRequest.php
+│   └── UpdateBookRequest.php
+└── Resources/
+    ├── PictureBookResource.php
+    ├── PictureBookCollection.php
+    └── GoogleBookResource.php
+```
+
+### PictureBookController
+
+```php
+class PictureBookController extends Controller
+{
+    // GET /api/v1/books/search?q={query}
+    public function search(Request $request, SearchGoogleBooksHandler $handler)
+
+    // GET /api/v1/families/{family}/books
+    public function index(Request $request, Family $family, ListBooksHandler $handler)
+
+    // POST /api/v1/families/{family}/books
+    public function store(StoreBookRequest $request, Family $family, AddBookHandler $handler)
+
+    // GET /api/v1/families/{family}/books/{pictureBook}
+    public function show(Family $family, PictureBook $pictureBook, GetBookHandler $handler)
+
+    // PUT /api/v1/families/{family}/books/{pictureBook}
+    public function update(UpdateBookRequest $request, Family $family, PictureBook $pictureBook, UpdateBookHandler $handler)
+
+    // DELETE /api/v1/families/{family}/books/{pictureBook}
+    public function destroy(Family $family, PictureBook $pictureBook, RemoveBookHandler $handler)
+}
+```
+
+### FormRequest バリデーション
+
+**`StoreBookRequest`**:
+| フィールド | ルール |
+|---|---|
+| `google_books_id` | `nullable`, `string`, `max:255` |
+| `isbn` | `nullable`, `string`, `max:13` |
+| `title` | `required`, `string`, `max:500` |
+| `authors` | `required`, `array` |
+| `authors.*` | `string`, `max:255` |
+| `thumbnail_url` | `nullable`, `url`, `max:2048` |
+
+**`UpdateBookRequest`**:
+| フィールド | ルール |
+|---|---|
+| `rating` | `nullable`, `integer`, `min:1`, `max:5` |
+| `read_status` | `required`, `string`, `in:unread,reading,read` |
+| `review` | `nullable`, `string`, `max:5000` |
+
+### API Resource
+
+**`GoogleBookResource`**（検索結果用）:
+```json
+{
+  "google_books_id": "xxxxx",
+  "title": "ぐりとぐら",
+  "authors": ["中川李枝子"],
+  "isbn": "9784834000825",
+  "thumbnail_url": "https://...",
+  "published_date": "1967-01-20",
+  "description": "...",
+  "page_count": 28
+}
+```
+
+**`PictureBookResource`**（本棚の絵本）:
+```json
+{
+  "id": 1,
+  "google_books_id": "xxxxx",
+  "isbn": "9784834000825",
+  "title": "ぐりとぐら",
+  "authors": ["中川李枝子"],
+  "thumbnail_url": "https://...",
+  "rating": 5,
+  "read_status": "read",
+  "review": "子どもが大好きな一冊",
+  "registered_by": {
+    "id": 1,
+    "name": "太郎"
+  },
+  "created_at": "2026-03-08T00:00:00.000000Z"
+}
+```
+
+**`PictureBookCollection`**（ページネーション付き一覧）:
+```json
+{
+  "data": [ /* PictureBookResource の配列 */ ],
+  "meta": {
+    "current_page": 1,
+    "last_page": 3,
+    "per_page": 20,
+    "total": 52
+  }
+}
+```
+
+### ルート定義 (`routes/api.php`)
+
+```php
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    // ... 既存ルート (auth, families, children) ...
+
+    // Google Books 検索（家族に紐付かない）
+    Route::get('/books/search', [PictureBookController::class, 'search']);
+
+    // 本棚（家族に紐付く）
+    Route::prefix('/families/{family}/books')->group(function () {
+        Route::get('/', [PictureBookController::class, 'index']);
+        Route::post('/', [PictureBookController::class, 'store']);
+        Route::get('/{pictureBook}', [PictureBookController::class, 'show']);
+        Route::put('/{pictureBook}', [PictureBookController::class, 'update']);
+        Route::delete('/{pictureBook}', [PictureBookController::class, 'destroy']);
+    });
+});
+```
+
+### クエリパラメータ（一覧取得）
+
+`GET /api/v1/families/{family}/books`:
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `status` | string | (全件) | `unread`, `reading`, `read` でフィルター |
+| `sort` | string | `created_at` | ソート対象 (`created_at`, `title`, `rating`) |
+| `order` | string | `desc` | `asc` or `desc` |
+| `per_page` | integer | `20` | 1ページあたりの件数（最大100） |
+| `page` | integer | `1` | ページ番号 |
+
+---
+
+## 4-7. 認可 — PictureBookPolicy
+
+### 認可ロジック
+
+Step 3 の FamilyPolicy を再利用し、本棚操作は家族所属チェックで保護:
+
+```php
+namespace App\Policies;
+
+class PictureBookPolicy
+{
+    // 本棚の閲覧・操作: 家族のメンバーか
+    public function manage(User $user, PictureBook $pictureBook): bool
+    {
+        return $user->family_id === $pictureBook->family_id;
+    }
+}
+```
+
+Controller では:
+- `index`, `store`: `FamilyPolicy::view` で家族所属チェック
+- `show`, `update`, `destroy`: `PictureBookPolicy::manage` で個別チェック
+
+### URL パラメータの整合性チェック
+
+ルートが `/families/{family}/books/{pictureBook}` のため、`pictureBook.family_id === family.id` の検証が必要。方法:
+
+| 方式 | 説明 |
+|---|---|
+| Route Model Binding のスコープ | `Route::scopeBindings()` で自動チェック |
+| Controller 内で手動チェック | 明示的だが冗長 |
+| Policy 内でチェック | 認可と同時に検証 |
+
+→ **Route Model Binding のスコープ**を採用。Laravel はネストされたルートモデルバインディングで自動的にスコープを適用できる:
+
+```php
+// routes/api.php — scopeBindings を使用
+Route::prefix('/families/{family}/books')->scopeBindings()->group(function () {
+    // {pictureBook} は自動的に {family} にスコープされる
+});
+```
+
+ただし `PictureBook` の `family()` リレーションが定義されている必要がある。
+
+---
+
+## 4-8. Feature テスト
+
+### テストファイル
+
+```
+backend/tests/Feature/
+└── Bookshelf/
+    ├── SearchGoogleBooksTest.php
+    ├── AddBookTest.php
+    ├── ListBooksTest.php
+    ├── GetBookTest.php
+    ├── UpdateBookTest.php
+    └── RemoveBookTest.php
+```
+
+### テストケース一覧
+
+**SearchGoogleBooksTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | キーワードで検索 | 200, Google Books の結果が返る |
+| 2 | クエリパラメータ `q` が空 | 422 |
+| 3 | 未認証でアクセス | 401 |
+
+> Google Books API はテスト時に Http::fake() でモックする
+
+**AddBookTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に絵本を登録 | 201, 登録された絵本情報 |
+| 2 | 同じ google_books_id で重複登録 | 409 or 422（既に登録済み） |
+| 3 | 必須フィールド欠落 | 422 |
+| 4 | 他家族の本棚に登録 | 403 |
+| 5 | google_books_id なしで手動登録 | 201 |
+
+**ListBooksTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 本棚一覧を取得 | 200, ページネーション付き |
+| 2 | read_status でフィルター | 200, 該当ステータスのみ |
+| 3 | 他家族の本棚を取得 | 403 |
+| 4 | 本棚が空 | 200, 空配列 |
+
+**GetBookTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 絵本詳細を取得 | 200, 絵本情報 |
+| 2 | 他家族の絵本を取得 | 403 |
+| 3 | 存在しない ID | 404 |
+
+**UpdateBookTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 評価・ステータス・レビューを更新 | 200 |
+| 2 | rating が範囲外（0 or 6） | 422 |
+| 3 | 無効な read_status | 422 |
+| 4 | 他家族の絵本を更新 | 403 |
+
+**RemoveBookTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に削除 | 200 or 204 |
+| 2 | 他家族の絵本を削除 | 403 |
+
+### Google Books API のモック
+
+```php
+use Illuminate\Support\Facades\Http;
+
+Http::fake([
+    'www.googleapis.com/books/v1/volumes*' => Http::response([
+        'totalItems' => 1,
+        'items' => [
+            [
+                'id' => 'test_google_id',
+                'volumeInfo' => [
+                    'title' => 'ぐりとぐら',
+                    'authors' => ['中川李枝子'],
+                    'industryIdentifiers' => [
+                        ['type' => 'ISBN_13', 'identifier' => '9784834000825'],
+                    ],
+                    'imageLinks' => [
+                        'thumbnail' => 'https://example.com/thumb.jpg',
+                    ],
+                ],
+            ],
+        ],
+    ]),
+]);
+```
+
+---
+
+## 4-9. フロントエンド — API 関数・型定義
+
+### `src/types/book.ts`
+
+```typescript
+export interface GoogleBook {
+  google_books_id: string;
+  title: string;
+  authors: string[];
+  isbn: string | null;
+  thumbnail_url: string | null;
+  published_date: string | null;
+  description: string | null;
+  page_count: number | null;
+}
+
+export interface PictureBook {
+  id: number;
+  google_books_id: string | null;
+  isbn: string | null;
+  title: string;
+  authors: string[];
+  thumbnail_url: string | null;
+  rating: number | null;
+  read_status: 'unread' | 'reading' | 'read';
+  review: string | null;
+  registered_by: { id: number; name: string };
+  created_at: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+  };
+}
+```
+
+### `src/api/books.ts`
+
+```typescript
+import apiClient from './client';
+
+export const searchGoogleBooks = (query: string) =>
+  apiClient.get('/books/search', { params: { q: query } });
+
+export const getBooks = (familyId: number, params?: {
+  status?: string;
+  sort?: string;
+  order?: string;
+  page?: number;
+  per_page?: number;
+}) =>
+  apiClient.get(`/families/${familyId}/books`, { params });
+
+export const addBook = (familyId: number, data: {
+  google_books_id?: string;
+  isbn?: string;
+  title: string;
+  authors: string[];
+  thumbnail_url?: string;
+}) =>
+  apiClient.post(`/families/${familyId}/books`, data);
+
+export const getBook = (familyId: number, bookId: number) =>
+  apiClient.get(`/families/${familyId}/books/${bookId}`);
+
+export const updateBook = (familyId: number, bookId: number, data: {
+  rating?: number | null;
+  read_status: string;
+  review?: string | null;
+}) =>
+  apiClient.put(`/families/${familyId}/books/${bookId}`, data);
+
+export const removeBook = (familyId: number, bookId: number) =>
+  apiClient.delete(`/families/${familyId}/books/${bookId}`);
+```
+
+---
+
+## 4-10. フロントエンド — カスタムフック
+
+### `src/hooks/useBooks.ts`
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useSearchGoogleBooks = (query: string) => {
+  return useQuery({
+    queryKey: ['googleBooks', query],
+    queryFn: () => searchGoogleBooks(query),
+    enabled: query.length >= 2,  // 2文字以上で検索
+  });
+};
+
+export const useBooks = (familyId: number, params?: { status?: string; page?: number }) => {
+  return useQuery({
+    queryKey: ['books', familyId, params],
+    queryFn: () => getBooks(familyId, params),
+  });
+};
+
+export const useBook = (familyId: number, bookId: number) => {
+  return useQuery({
+    queryKey: ['book', familyId, bookId],
+    queryFn: () => getBook(familyId, bookId),
+  });
+};
+
+export const useAddBook = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data) => addBook(familyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['books', familyId] });
+    },
+  });
+};
+
+export const useUpdateBook = (familyId: number, bookId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data) => updateBook(familyId, bookId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['book', familyId, bookId] });
+      queryClient.invalidateQueries({ queryKey: ['books', familyId] });
+    },
+  });
+};
+
+export const useRemoveBook = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (bookId: number) => removeBook(familyId, bookId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['books', familyId] });
+    },
+  });
+};
+```
+
+---
+
+## 4-11. フロントエンド — ページコンポーネント
+
+### ルーティング構成（Step 3 からの追加）
+
+```typescript
+<Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+  <Route path="/" element={<DashboardPage />} />
+  <Route path="/family/create" element={<CreateFamilyPage />} />
+  <Route path="/family/settings" element={<FamilySettingsPage />} />
+
+  {/* Step 4 で追加 */}
+  <Route path="/books/search" element={<BookSearchPage />} />
+  <Route path="/books" element={<BookshelfPage />} />
+  <Route path="/books/:bookId" element={<BookDetailPage />} />
+</Route>
+```
+
+### BookSearchPage
+
+- 検索キーワード入力フォーム（デバウンス 300ms）
+- 検索結果を `GoogleBookCard` コンポーネントでリスト表示
+- 各カードに「本棚に追加」ボタン
+- 追加済みの本は「登録済み」と表示（重複防止の UX）
+- 追加成功時にトースト通知
+- 「手動で追加」リンク → 手動登録フォーム（Google Books にない絵本用）
+
+### BookManualAddForm（手動登録）
+
+- BookSearchPage 内、または別モーダルとして表示
+- フィールド: `title`（必須）, `authors`（必須、カンマ区切りまたは複数入力）, `isbn`（任意）
+- Google Books 検索で見つからない絵本を手動で本棚に追加する導線
+
+**デバウンスの実装**:
+```typescript
+const [query, setQuery] = useState('');
+const debouncedQuery = useDebounce(query, 300);
+const { data, isLoading } = useSearchGoogleBooks(debouncedQuery);
+```
+
+> `useDebounce` はカスタムフックとして実装（useState + useEffect）
+
+### BookshelfPage
+
+- ステータスフィルタータブ: 全て / 未読 / 読書中 / 読了
+- 本棚一覧を `BookCard` コンポーネントのグリッド表示
+- ページネーション（ページ番号 or 無限スクロール）
+- 絵本検索ページへのリンクボタン
+- 空状態: 「まだ絵本が登録されていません。検索して追加しましょう」
+
+### BookCard コンポーネント
+
+- サムネイル画像（fallback あり: 画像なし時のプレースホルダー）
+- タイトル、著者
+- 読書ステータスバッジ
+- 評価（星表示）
+- クリックで BookDetailPage へ遷移
+
+### BookDetailPage
+
+- 絵本の詳細情報表示
+- 評価の設定（星をクリック）
+- 読書ステータスの変更（セレクト or ボタン群）
+- レビューの編集（テキストエリア）
+- 本棚から削除ボタン（確認ダイアログ付き）
+- Step 5 で読み聞かせ記録セクションを追加予定
+
+---
+
+## 4-12. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | マイグレーション | `task migrate` | picture_books テーブル作成 |
+| 2 | Google Books 検索 | `curl .../books/search?q=ぐりとぐら` | 200, 検索結果 |
+| 3 | 絵本登録 | `curl -X POST .../families/{id}/books` | 201 |
+| 4 | 重複登録チェック | 同じ google_books_id で再度 POST | 409 or 422 |
+| 5 | 本棚一覧 | `curl .../families/{id}/books` | 200, ページネーション付き |
+| 6 | ステータスフィルター | `curl .../families/{id}/books?status=read` | 200, フィルター済み |
+| 7 | 絵本詳細 | `curl .../families/{id}/books/{bookId}` | 200 |
+| 8 | 絵本更新 | `curl -X PUT .../families/{id}/books/{bookId}` | 200 |
+| 9 | 絵本削除 | `curl -X DELETE .../families/{id}/books/{bookId}` | 200 or 204 |
+| 10 | 認可: 他家族 | 所属していない family_id でアクセス | 403 |
+| 11 | React 検索フロー | BookSearchPage でキーワード入力 → 結果表示 → 「本棚に追加」 | 本棚に反映 |
+| 12 | React 本棚一覧 | BookshelfPage でフィルター・ページ遷移 | 正しく表示 |
+| 13 | React 絵本詳細 | BookDetailPage で評価・ステータス・レビュー更新 | 保存される |
+| 14 | Feature テスト | `task test` | 全テスト通過 |
+
+---
+
+## 作業順序まとめ
+
+```
+4-1.  マイグレーション (picture_books)
+         ↓
+4-2.  Domain 層 (Entity, ValueObject, RepositoryInterface)
+         ↓
+4-3.  Application 層 (Command/Query Handler)
+         ↓
+4-4.  Infrastructure 層 (EloquentRepository, GoogleBooksApiClient, ServiceProvider バインド)
+         ↓
+4-5.  Eloquent Model (PictureBook, Family リレーション追加)
+         ↓
+4-6.  Interface 層 (Controller, Request, Resource, Routes)
+         ↓
+4-7.  認可 (PictureBookPolicy, scopeBindings)
+         ↓
+4-8.  Feature テスト作成・実行
+         ↓
+4-9.  フロントエンド 型定義 + API 関数
+         ↓
+4-10. カスタムフック (useBooks, useSearchGoogleBooks)
+         ↓
+4-11. ページコンポーネント (BookSearch, Bookshelf, BookDetail)
+         ↓
+4-12. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **Value Object の共有**: `FamilyId`, `UserId`, `PictureBookId` は共有カーネル（`packages/Shared/ValueObject/`）から参照。rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照
+- **registered_by の外部キー**: `nullOnDelete` を使用。ユーザーが削除されても絵本データは残る（`registered_by` が null になる）
+- **Google Books API キー**: Phase 1 では API キーなしで利用。レート制限に引っかかったら追加
+- **サムネイル URL**: `http://` → `https://` に書き換えて保存。mixed content 回避
+- **authors の JSON 型**: 正規化せず配列をそのまま保存。著者別検索の要件がないため
+- **read_status**: DB は string、Domain は PHP Enum で管理
+- **重複登録チェック**: `family_id` + `google_books_id` の組み合わせで判定。手動登録（google_books_id なし）は重複チェックなし
+- **Route Model Binding スコープ**: `scopeBindings()` で `{pictureBook}` が `{family}` に自動スコープされるため、URL パラメータの整合性を手動チェックする必要がない
+- **絵本削除時の影響**: Step 5 で `read_records` テーブルが追加された後は、絵本削除時の関連レコードの扱い（cascade delete or soft delete）を検討する必要がある。Step 4 時点では単純削除で問題ない
+- **ページネーション**: Laravel 標準の `paginate()` を使用。フロントエンドではページ番号方式を先に実装し、必要に応じて無限スクロールに変更

--- a/docs/plans/step5-read-records.md
+++ b/docs/plans/step5-read-records.md
@@ -1,0 +1,1162 @@
+# Step 5: 読み聞かせ記録 (Read Records) — 詳細プラン
+
+## ゴール
+
+絵本ごとに読み聞かせ記録を作成・管理できる状態にする。記録には日付、対象の子ども（複数可）、子どもごとのリアクション、タグ、メモを含む。
+ReadLog コンテキストを DDD + Clean Architecture + CQRS の構成で実装する。
+
+## 完了条件
+
+- [ ] `POST /api/v1/families/{family}/records` で読み聞かせ記録を作成できる
+- [ ] `GET /api/v1/families/{family}/records` でフィルター・ページネーション付き一覧を取得できる
+- [ ] `GET /api/v1/families/{family}/records/{record}` で記録詳細を取得できる
+- [ ] `PUT /api/v1/families/{family}/records/{record}` で記録を更新できる
+- [ ] `DELETE /api/v1/families/{family}/records/{record}` で記録を削除できる
+- [ ] `GET /api/v1/tags?q={query}` でタグのオートコンプリート候補が返る
+- [ ] 1つの記録に複数の子ども + 子どもごとのリアクションを紐付けられる
+- [ ] タグの新規作成と既存タグの紐付けが同時にできる
+- [ ] 他家族の記録にアクセスすると 403 が返る
+- [ ] React SPA から記録の作成・一覧・詳細・編集・削除が動作する
+- [ ] BookDetailPage 内に読み聞かせ記録セクションが統合される
+- [ ] Feature テストが全て通る
+
+---
+
+## 5-1. マイグレーション
+
+### `create_read_records_table`
+
+```php
+Schema::create('read_records', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('picture_book_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('family_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('recorded_by')->constrained('users')->cascadeOnDelete();
+    $table->date('read_date');
+    $table->text('memo')->nullable();
+    $table->timestamps();
+
+    $table->index(['family_id', 'read_date']);
+    $table->index(['picture_book_id', 'read_date']);
+});
+```
+
+### `create_child_read_record_table`（ピボットテーブル）
+
+```php
+Schema::create('child_read_record', function (Blueprint $table) {
+    $table->foreignId('child_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('read_record_id')->constrained()->cascadeOnDelete();
+    $table->string('reaction')->nullable();
+    $table->primary(['child_id', 'read_record_id']);
+});
+```
+
+### `create_tags_table`
+
+```php
+Schema::create('tags', function (Blueprint $table) {
+    $table->id();
+    $table->string('name')->unique();
+    $table->timestamps();
+});
+```
+
+### `create_read_record_tag_table`（ピボットテーブル）
+
+```php
+Schema::create('read_record_tag', function (Blueprint $table) {
+    $table->foreignId('read_record_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+    $table->primary(['read_record_id', 'tag_id']);
+});
+```
+
+### 設計判断: child_read_record の reaction カラム
+
+旧アプリでは読み聞かせ記録に 1 つのリアクションだった。新アプリでは子どもごとにリアクションを記録する:
+
+| 旧 | 新 |
+|---|---|
+| `read_records.reaction` | `child_read_record.reaction`（ピボットテーブル上） |
+
+→ 同じ絵本を読んでも、長男は「大喜び」、次男は「途中で飽きた」など、子どもごとに異なるリアクションを記録できる。
+
+### 設計判断: reaction の型
+
+| 方式 | 説明 |
+|---|---|
+| 定義済み選択肢（Enum） | `loved`, `enjoyed`, `bored`, `cried` 等の固定値 |
+| 自由テキスト | ユーザーが自由に入力 |
+
+→ **自由テキスト（string）を採用**。理由:
+- リアクションの表現は多様で、定義済み選択肢では表現しきれない
+- 個人開発アプリのため、自由度を優先
+- フロントエンドでよく使うリアクションをサジェストとして表示する程度の補助は可能
+
+### 設計判断: tags のスコープ
+
+| 方式 | 説明 |
+|---|---|
+| グローバル（全ユーザー共有） | タグマスタが 1 つ。他家族が作ったタグも検索候補に出る |
+| 家族スコープ（`tags.family_id`） | 家族ごとにタグを管理。他家族のタグは見えない |
+
+→ **グローバルを採用**。理由:
+- rebuild-plan のスキーマに `tags.family_id` がない（`id, name(unique)` のみ）
+- タグ名自体は「寝る前」「お気に入り」等の汎用的な語句で、家族間で共有しても問題ない
+- 実装がシンプル
+- タグの表示はあくまで紐付けた記録に対してなので、他家族の記録が見えるわけではない
+
+### 確認ポイント
+
+- `task migrate` で 4 テーブルが作成される
+
+---
+
+## 5-2. ReadLog コンテキスト — Domain 層
+
+### ディレクトリ構成
+
+```
+backend/packages/ReadLog/
+├── Domain/
+│   ├── Entity/
+│   │   ├── ReadRecord.php
+│   │   └── Tag.php
+│   ├── ValueObject/
+│   │   ├── ReadDate.php
+│   │   ├── Reaction.php
+│   │   ├── ChildReaction.php     # child_id + reaction のペア
+│   │   └── TagId.php
+│   └── Repository/
+│       ├── ReadRecordRepositoryInterface.php
+│       └── TagRepositoryInterface.php
+```
+
+> `ReadRecordId` は不要（`ReadRecord` Entity の ID は共有カーネルに含めず、Entity 内で `?int` として管理）。
+> `FamilyId`, `UserId`, `ChildId`, `PictureBookId` は共有カーネル（`packages/Shared/ValueObject/`）から参照。詳細は rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照。
+
+### Domain Entity: `ReadRecord`
+
+```php
+namespace Packages\ReadLog\Domain\Entity;
+
+final class ReadRecord
+{
+    /**
+     * @param ChildReaction[] $childReactions
+     * @param TagId[] $tagIds
+     */
+    public function __construct(
+        private readonly ?ReadRecordId $id,
+        private readonly PictureBookId $pictureBookId,
+        private readonly FamilyId $familyId,
+        private readonly UserId $recordedBy,
+        private ReadDate $readDate,
+        private ?string $memo,
+        private array $childReactions,
+        private array $tagIds,
+    ) {}
+
+    public static function create(
+        PictureBookId $pictureBookId,
+        FamilyId $familyId,
+        UserId $recordedBy,
+        ReadDate $readDate,
+        ?string $memo,
+        array $childReactions,
+        array $tagIds,
+    ): self {
+        return new self(
+            null, $pictureBookId, $familyId, $recordedBy,
+            $readDate, $memo, $childReactions, $tagIds,
+        );
+    }
+
+    public function update(
+        ReadDate $readDate,
+        ?string $memo,
+        array $childReactions,
+        array $tagIds,
+    ): void {
+        $this->readDate = $readDate;
+        $this->memo = $memo;
+        $this->childReactions = $childReactions;
+        $this->tagIds = $tagIds;
+    }
+
+    // Getter, reconstruct メソッド
+}
+```
+
+### Domain Entity: `Tag`
+
+```php
+namespace Packages\ReadLog\Domain\Entity;
+
+final class Tag
+{
+    public function __construct(
+        private readonly ?TagId $id,
+        private readonly string $name,
+    ) {}
+
+    public static function create(string $name): self
+    {
+        return new self(null, $name);
+    }
+
+    // Getter, reconstruct メソッド
+}
+```
+
+### Value Objects
+
+| クラス | 内容 |
+|---|---|
+| `ReadRecordId` | 正の整数 |
+| `ReadDate` | 過去または今日の日付。未来日を拒否 |
+| `Reaction` | 0〜255文字の自由テキスト |
+| `ChildReaction` | `ChildId` + `Reaction` のペア（Value Object） |
+| `TagId` | 正の整数 |
+
+### ChildReaction（Value Object）
+
+```php
+namespace Packages\ReadLog\Domain\ValueObject;
+
+final class ChildReaction
+{
+    public function __construct(
+        private readonly ChildId $childId,
+        private readonly ?Reaction $reaction,
+    ) {}
+
+    // Getter メソッド
+}
+```
+
+### Repository Interfaces
+
+**`ReadRecordRepositoryInterface`**:
+```php
+interface ReadRecordRepositoryInterface
+{
+    public function findById(ReadRecordId $id): ?ReadRecord;
+    public function save(ReadRecord $record): ReadRecord;
+    public function delete(ReadRecordId $id): void;
+}
+```
+
+**`TagRepositoryInterface`**:
+```php
+interface TagRepositoryInterface
+{
+    public function findByName(string $name): ?Tag;
+    public function findOrCreateByNames(array $names): array;  // Tag[]
+}
+```
+
+### 設計判断: ReadRecord Entity に childReactions と tagIds を含める
+
+読み聞かせ記録は「どの子どもに読んだか（+リアクション）」「どのタグを付けたか」が不可分の情報。集約ルート (Aggregate Root) として ReadRecord が子ども紐付けとタグ紐付けを管理する。
+
+→ 保存時にピボットテーブルの sync を Repository 内で行う。
+
+---
+
+## 5-3. ReadLog コンテキスト — Application 層
+
+### ディレクトリ構成
+
+```
+backend/packages/ReadLog/
+├── Application/
+│   ├── Command/
+│   │   ├── CreateRecord/
+│   │   │   ├── CreateRecordCommand.php
+│   │   │   └── CreateRecordHandler.php
+│   │   ├── UpdateRecord/
+│   │   │   ├── UpdateRecordCommand.php
+│   │   │   └── UpdateRecordHandler.php
+│   │   └── DeleteRecord/
+│   │       ├── DeleteRecordCommand.php
+│   │       └── DeleteRecordHandler.php
+│   └── Query/
+│       ├── ListRecords/
+│       │   ├── ListRecordsQuery.php
+│       │   └── ListRecordsHandler.php
+│       ├── GetRecord/
+│       │   ├── GetRecordQuery.php
+│       │   └── GetRecordHandler.php
+│       └── SearchTags/
+│           ├── SearchTagsQuery.php
+│           └── SearchTagsHandler.php
+```
+
+### CreateRecord
+
+**`CreateRecordCommand`** (DTO):
+```php
+final class CreateRecordCommand
+{
+    /**
+     * @param array<int, string|null> $childReactions  // [child_id => reaction]
+     * @param string[] $tags                           // タグ名の配列
+     */
+    public function __construct(
+        public readonly int $pictureBookId,
+        public readonly int $familyId,
+        public readonly int $userId,
+        public readonly string $readDate,
+        public readonly ?string $memo,
+        public readonly array $childReactions,
+        public readonly array $tags,
+    ) {}
+}
+```
+
+**`CreateRecordHandler`**:
+1. `TagRepository::findOrCreateByNames()` でタグを取得 or 新規作成し、TagId の配列を得る
+2. `childReactions` 配列を `ChildReaction` Value Object の配列に変換
+3. `ReadRecord::create()` でエンティティ生成
+4. `ReadRecordRepository::save()` で永続化（ピボットテーブル含む）
+5. 作成された ReadRecord を返却
+
+### UpdateRecord
+
+**`UpdateRecordHandler`**:
+1. `ReadRecordRepository::findById()` で取得
+2. タグの findOrCreate
+3. `ReadRecord::update()` で更新
+4. `ReadRecordRepository::save()` で永続化（ピボットテーブルを sync）
+
+### DeleteRecord
+
+**`DeleteRecordHandler`**:
+1. `ReadRecordRepository::delete()` で削除（cascade でピボットも削除）
+
+### ListRecords（Query）
+
+**`ListRecordsQuery`**:
+```php
+final class ListRecordsQuery
+{
+    public function __construct(
+        public readonly int $familyId,
+        public readonly ?int $childId = null,
+        public readonly ?int $pictureBookId = null,
+        public readonly ?string $dateFrom = null,
+        public readonly ?string $dateTo = null,
+        public readonly int $perPage = 20,
+        public readonly int $page = 1,
+    ) {}
+}
+```
+
+**`ListRecordsHandler`**:
+- Eloquent を直接使い、条件付きクエリを構築
+- Eager load: `children`（ピボットの reaction 含む）、`tags`、`pictureBook`、`recordedByUser`
+- ソート: `read_date` desc（デフォルト）
+- ページネーション
+
+### GetRecord（Query）
+
+**`GetRecordHandler`**:
+- Eloquent で記録詳細を取得（リレーション Eager load）
+
+### SearchTags（Query）
+
+**`SearchTagsQuery`**:
+```php
+final class SearchTagsQuery
+{
+    public function __construct(
+        public readonly string $keyword,
+        public readonly int $limit = 10,
+    ) {}
+}
+```
+
+**`SearchTagsHandler`**:
+- `Tag::where('name', 'like', "{$keyword}%")->limit($limit)->get()`
+- オートコンプリート用。前方一致で高速検索
+
+---
+
+## 5-4. ReadLog コンテキスト — Infrastructure 層
+
+### ディレクトリ構成
+
+```
+backend/packages/ReadLog/
+└── Infrastructure/
+    └── Repository/
+        ├── EloquentReadRecordRepository.php
+        └── EloquentTagRepository.php
+```
+
+### EloquentReadRecordRepository
+
+```php
+namespace Packages\ReadLog\Infrastructure\Repository;
+
+final class EloquentReadRecordRepository implements ReadRecordRepositoryInterface
+{
+    public function findById(ReadRecordId $id): ?ReadRecord
+    {
+        $model = EloquentReadRecord::with(['children', 'tags'])->find($id->value());
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function save(ReadRecord $record): ReadRecord
+    {
+        if ($record->id() === null) {
+            $model = EloquentReadRecord::create([
+                'picture_book_id' => $record->pictureBookId()->value(),
+                'family_id' => $record->familyId()->value(),
+                'recorded_by' => $record->recordedBy()->value(),
+                'read_date' => $record->readDate()->value(),
+                'memo' => $record->memo(),
+            ]);
+        } else {
+            $model = EloquentReadRecord::findOrFail($record->id()->value());
+            $model->update([
+                'read_date' => $record->readDate()->value(),
+                'memo' => $record->memo(),
+            ]);
+        }
+
+        // ピボットテーブル sync: children + reaction
+        $childrenSync = [];
+        foreach ($record->childReactions() as $cr) {
+            $childrenSync[$cr->childId()->value()] = ['reaction' => $cr->reaction()?->value()];
+        }
+        $model->children()->sync($childrenSync);
+
+        // ピボットテーブル sync: tags
+        $tagIds = array_map(fn ($tagId) => $tagId->value(), $record->tagIds());
+        $model->tags()->sync($tagIds);
+
+        return $this->toDomainEntity($model->fresh(['children', 'tags']));
+    }
+
+    public function delete(ReadRecordId $id): void
+    {
+        EloquentReadRecord::destroy($id->value());
+    }
+
+    private function toDomainEntity(EloquentReadRecord $model): ReadRecord { /* ... */ }
+}
+```
+
+### EloquentTagRepository
+
+```php
+namespace Packages\ReadLog\Infrastructure\Repository;
+
+final class EloquentTagRepository implements TagRepositoryInterface
+{
+    public function findByName(string $name): ?Tag
+    {
+        $model = EloquentTag::where('name', $name)->first();
+        return $model ? Tag::reconstruct(new TagId($model->id), $model->name) : null;
+    }
+
+    public function findOrCreateByNames(array $names): array
+    {
+        return array_map(function (string $name) {
+            $model = EloquentTag::firstOrCreate(['name' => trim($name)]);
+            return Tag::reconstruct(new TagId($model->id), $model->name);
+        }, $names);
+    }
+}
+```
+
+### ServiceProvider でのバインド
+
+```php
+$this->app->bind(ReadRecordRepositoryInterface::class, EloquentReadRecordRepository::class);
+$this->app->bind(TagRepositoryInterface::class, EloquentTagRepository::class);
+```
+
+---
+
+## 5-5. Eloquent Model
+
+### `app/Models/ReadRecord.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ReadRecord extends Model
+{
+    protected $fillable = [
+        'picture_book_id',
+        'family_id',
+        'recorded_by',
+        'read_date',
+        'memo',
+    ];
+
+    protected $casts = [
+        'read_date' => 'date',
+    ];
+
+    public function pictureBook(): BelongsTo
+    {
+        return $this->belongsTo(PictureBook::class);
+    }
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(Family::class);
+    }
+
+    public function recordedByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recorded_by');
+    }
+
+    public function children(): BelongsToMany
+    {
+        return $this->belongsToMany(Child::class, 'child_read_record')
+            ->withPivot('reaction');
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'read_record_tag');
+    }
+}
+```
+
+### `app/Models/Tag.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+
+    public function readRecords(): BelongsToMany
+    {
+        return $this->belongsToMany(ReadRecord::class, 'read_record_tag');
+    }
+}
+```
+
+### 既存モデルへのリレーション追加
+
+**`app/Models/PictureBook.php`**:
+```php
+public function readRecords(): HasMany
+{
+    return $this->hasMany(ReadRecord::class);
+}
+```
+
+**`app/Models/Child.php`**:
+```php
+public function readRecords(): BelongsToMany
+{
+    return $this->belongsToMany(ReadRecord::class, 'child_read_record')
+        ->withPivot('reaction');
+}
+```
+
+**`app/Models/Family.php`**:
+```php
+public function readRecords(): HasMany
+{
+    return $this->hasMany(ReadRecord::class);
+}
+```
+
+---
+
+## 5-6. Interface 層 — Controller, Request, Resource, Routes
+
+### ディレクトリ構成
+
+```
+backend/app/Http/
+├── Controllers/Api/
+│   ├── ReadRecordController.php
+│   └── TagController.php
+├── Requests/
+│   ├── StoreReadRecordRequest.php
+│   └── UpdateReadRecordRequest.php
+└── Resources/
+    ├── ReadRecordResource.php
+    ├── ReadRecordCollection.php
+    └── TagResource.php
+```
+
+### ReadRecordController
+
+```php
+class ReadRecordController extends Controller
+{
+    // GET /api/v1/families/{family}/records
+    public function index(Request $request, Family $family, ListRecordsHandler $handler)
+
+    // POST /api/v1/families/{family}/records
+    public function store(StoreReadRecordRequest $request, Family $family, CreateRecordHandler $handler)
+
+    // GET /api/v1/families/{family}/records/{readRecord}
+    public function show(Family $family, ReadRecord $readRecord, GetRecordHandler $handler)
+
+    // PUT /api/v1/families/{family}/records/{readRecord}
+    public function update(UpdateReadRecordRequest $request, Family $family, ReadRecord $readRecord, UpdateRecordHandler $handler)
+
+    // DELETE /api/v1/families/{family}/records/{readRecord}
+    public function destroy(Family $family, ReadRecord $readRecord, DeleteRecordHandler $handler)
+}
+```
+
+### TagController
+
+```php
+class TagController extends Controller
+{
+    // GET /api/v1/tags?q={query}
+    public function index(Request $request, SearchTagsHandler $handler)
+}
+```
+
+### FormRequest バリデーション
+
+**`StoreReadRecordRequest`** / **`UpdateReadRecordRequest`**:
+| フィールド | ルール |
+|---|---|
+| `picture_book_id` | `required` (store のみ), `integer`, `exists:picture_books,id` |
+| `read_date` | `required`, `date`, `before_or_equal:today` |
+| `memo` | `nullable`, `string`, `max:5000` |
+| `children` | `required`, `array`, `min:1` |
+| `children.*.child_id` | `required`, `integer`, `exists:children,id` |
+| `children.*.reaction` | `nullable`, `string`, `max:255` |
+| `tags` | `nullable`, `array` |
+| `tags.*` | `string`, `max:50` |
+
+**追加バリデーション（カスタムルール）**:
+- `children.*.child_id` が指定された `family` に属していること
+- `picture_book_id` が指定された `family` に属していること
+
+```php
+public function withValidator($validator)
+{
+    $validator->after(function ($validator) {
+        $family = $this->route('family');
+
+        // 子どもが家族に属しているか
+        $childIds = collect($this->children)->pluck('child_id');
+        $validChildCount = Child::where('family_id', $family->id)
+            ->whereIn('id', $childIds)
+            ->count();
+        if ($validChildCount !== $childIds->count()) {
+            $validator->errors()->add('children', 'Invalid child specified.');
+        }
+
+        // 絵本が家族に属しているか (store のみ)
+        if ($this->picture_book_id) {
+            $bookExists = PictureBook::where('id', $this->picture_book_id)
+                ->where('family_id', $family->id)
+                ->exists();
+            if (!$bookExists) {
+                $validator->errors()->add('picture_book_id', 'Invalid picture book specified.');
+            }
+        }
+    });
+}
+```
+
+### API Resource
+
+**`ReadRecordResource`**:
+```json
+{
+  "id": 1,
+  "picture_book": {
+    "id": 1,
+    "title": "ぐりとぐら",
+    "thumbnail_url": "https://..."
+  },
+  "read_date": "2026-03-08",
+  "memo": "寝る前に読んだ",
+  "children": [
+    {
+      "id": 1,
+      "name": "はなこ",
+      "reaction": "大喜びで何度もリクエスト"
+    },
+    {
+      "id": 2,
+      "name": "たろう",
+      "reaction": "途中で寝た"
+    }
+  ],
+  "tags": [
+    { "id": 1, "name": "寝る前" },
+    { "id": 2, "name": "お気に入り" }
+  ],
+  "recorded_by": {
+    "id": 1,
+    "name": "パパ"
+  },
+  "created_at": "2026-03-08T00:00:00.000000Z"
+}
+```
+
+**`TagResource`**:
+```json
+{
+  "id": 1,
+  "name": "寝る前"
+}
+```
+
+### ルート定義 (`routes/api.php`)
+
+```php
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    // ... 既存ルート (auth, families, children, books) ...
+
+    // 読み聞かせ記録
+    Route::prefix('/families/{family}/records')->scopeBindings()->group(function () {
+        Route::get('/', [ReadRecordController::class, 'index']);
+        Route::post('/', [ReadRecordController::class, 'store']);
+        Route::get('/{readRecord}', [ReadRecordController::class, 'show']);
+        Route::put('/{readRecord}', [ReadRecordController::class, 'update']);
+        Route::delete('/{readRecord}', [ReadRecordController::class, 'destroy']);
+    });
+
+    // タグ検索（家族に紐付かない）
+    Route::get('/tags', [TagController::class, 'index']);
+});
+```
+
+### クエリパラメータ（一覧取得）
+
+`GET /api/v1/families/{family}/records`:
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `child_id` | integer | (全件) | 子どもでフィルター |
+| `picture_book_id` | integer | (全件) | 絵本でフィルター |
+| `date_from` | date | (制限なし) | 読んだ日の開始 |
+| `date_to` | date | (制限なし) | 読んだ日の終了 |
+| `per_page` | integer | `20` | 1ページあたりの件数（最大100） |
+| `page` | integer | `1` | ページ番号 |
+
+---
+
+## 5-7. 認可 — ReadRecordPolicy
+
+```php
+namespace App\Policies;
+
+class ReadRecordPolicy
+{
+    public function manage(User $user, ReadRecord $readRecord): bool
+    {
+        return $user->family_id === $readRecord->family_id;
+    }
+}
+```
+
+Controller では Step 4 と同様に:
+- `index`, `store`: `FamilyPolicy::view` で家族所属チェック
+- `show`, `update`, `destroy`: `ReadRecordPolicy::manage` + `scopeBindings` で検証
+
+---
+
+## 5-8. Feature テスト
+
+### テストファイル
+
+```
+backend/tests/Feature/
+└── ReadLog/
+    ├── CreateRecordTest.php
+    ├── ListRecordsTest.php
+    ├── GetRecordTest.php
+    ├── UpdateRecordTest.php
+    ├── DeleteRecordTest.php
+    └── SearchTagsTest.php
+```
+
+### テストケース一覧
+
+**CreateRecordTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に記録を作成（子ども1人、タグなし） | 201 |
+| 2 | 複数の子ども + リアクション付きで作成 | 201, 各子どものリアクションが保存 |
+| 3 | 新規タグ + 既存タグを同時に指定 | 201, タグが正しく紐付け |
+| 4 | children が空配列 | 422（最低1人必要） |
+| 5 | 他家族の絵本を指定 | 422 |
+| 6 | 他家族の子どもを指定 | 422 |
+| 7 | read_date が未来日 | 422 |
+| 8 | 他家族の記録として作成 | 403 |
+
+**ListRecordsTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 一覧取得（ページネーション） | 200 |
+| 2 | child_id でフィルター | 200, 該当子どもの記録のみ |
+| 3 | picture_book_id でフィルター | 200, 該当絵本の記録のみ |
+| 4 | 日付範囲でフィルター | 200, 範囲内の記録のみ |
+| 5 | 他家族の記録一覧 | 403 |
+
+**GetRecordTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 記録詳細を取得（children, tags, pictureBook 含む） | 200 |
+| 2 | 他家族の記録 | 403 |
+
+**UpdateRecordTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 日付・メモ・子ども・タグを更新 | 200 |
+| 2 | 子どもの追加・削除・リアクション変更 | 200, ピボットが正しく sync |
+| 3 | タグの追加・削除 | 200, ピボットが正しく sync |
+| 4 | 他家族の記録を更新 | 403 |
+
+**DeleteRecordTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に削除 | 200 or 204, ピボットも削除 |
+| 2 | 他家族の記録を削除 | 403 |
+| 3 | 削除後にタグ自体は残る | タグマスタは削除されない |
+
+**SearchTagsTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | キーワードでタグ検索 | 200, 前方一致の候補 |
+| 2 | 該当なし | 200, 空配列 |
+| 3 | q パラメータなし | 422 or 200（最近使われたタグを返す等） |
+
+---
+
+## 5-9. フロントエンド — 型定義・API 関数
+
+### `src/types/record.ts`
+
+```typescript
+export interface ChildReaction {
+  child_id: number;
+  name: string;         // 表示用
+  reaction: string | null;
+}
+
+export interface ReadRecord {
+  id: number;
+  picture_book: {
+    id: number;
+    title: string;
+    thumbnail_url: string | null;
+  };
+  read_date: string;    // "2026-03-08"
+  memo: string | null;
+  children: ChildReaction[];
+  tags: { id: number; name: string }[];
+  recorded_by: { id: number; name: string };
+  created_at: string;
+}
+
+export interface CreateRecordData {
+  picture_book_id: number;
+  read_date: string;
+  memo?: string;
+  children: { child_id: number; reaction?: string }[];
+  tags?: string[];
+}
+```
+
+### `src/api/records.ts`
+
+```typescript
+import apiClient from './client';
+
+export const getRecords = (familyId: number, params?: {
+  child_id?: number;
+  picture_book_id?: number;
+  date_from?: string;
+  date_to?: string;
+  page?: number;
+  per_page?: number;
+}) =>
+  apiClient.get(`/families/${familyId}/records`, { params });
+
+export const createRecord = (familyId: number, data: CreateRecordData) =>
+  apiClient.post(`/families/${familyId}/records`, data);
+
+export const getRecord = (familyId: number, recordId: number) =>
+  apiClient.get(`/families/${familyId}/records/${recordId}`);
+
+export const updateRecord = (familyId: number, recordId: number, data: Partial<CreateRecordData>) =>
+  apiClient.put(`/families/${familyId}/records/${recordId}`, data);
+
+export const deleteRecord = (familyId: number, recordId: number) =>
+  apiClient.delete(`/families/${familyId}/records/${recordId}`);
+
+export const searchTags = (query: string) =>
+  apiClient.get('/tags', { params: { q: query } });
+```
+
+---
+
+## 5-10. フロントエンド — カスタムフック
+
+### `src/hooks/useRecords.ts`
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useRecords = (familyId: number, params?: {
+  child_id?: number;
+  picture_book_id?: number;
+  date_from?: string;
+  date_to?: string;
+  page?: number;
+}) => {
+  return useQuery({
+    queryKey: ['records', familyId, params],
+    queryFn: () => getRecords(familyId, params),
+  });
+};
+
+export const useRecord = (familyId: number, recordId: number) => {
+  return useQuery({
+    queryKey: ['record', familyId, recordId],
+    queryFn: () => getRecord(familyId, recordId),
+  });
+};
+
+export const useCreateRecord = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateRecordData) => createRecord(familyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['records', familyId] });
+    },
+  });
+};
+
+export const useUpdateRecord = (familyId: number, recordId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data) => updateRecord(familyId, recordId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['record', familyId, recordId] });
+      queryClient.invalidateQueries({ queryKey: ['records', familyId] });
+    },
+  });
+};
+
+export const useDeleteRecord = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (recordId: number) => deleteRecord(familyId, recordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['records', familyId] });
+    },
+  });
+};
+
+export const useSearchTags = (query: string) => {
+  return useQuery({
+    queryKey: ['tags', query],
+    queryFn: () => searchTags(query),
+    enabled: query.length >= 1,
+  });
+};
+```
+
+---
+
+## 5-11. フロントエンド — ページコンポーネント
+
+### ルーティング構成（Step 4 からの追加）
+
+```typescript
+<Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+  <Route path="/" element={<DashboardPage />} />
+  <Route path="/family/create" element={<CreateFamilyPage />} />
+  <Route path="/family/settings" element={<FamilySettingsPage />} />
+  <Route path="/books/search" element={<BookSearchPage />} />
+  <Route path="/books" element={<BookshelfPage />} />
+  <Route path="/books/:bookId" element={<BookDetailPage />} />
+
+  {/* Step 5 で追加 */}
+  <Route path="/records" element={<RecordListPage />} />
+  <Route path="/records/new" element={<RecordCreatePage />} />
+  <Route path="/records/:recordId" element={<RecordDetailPage />} />
+  <Route path="/records/:recordId/edit" element={<RecordEditPage />} />
+</Route>
+```
+
+### RecordCreatePage + RecordForm
+
+記録作成フォーム。React Hook Form で管理:
+
+**フォームフィールド**:
+
+| フィールド | UI | 説明 |
+|---|---|---|
+| 絵本選択 | セレクト or 検索フィールド | 本棚の絵本から選択 |
+| 日付 | date input | デフォルト: 今日 |
+| 子ども | チェックボックス群 | 家族の子ども一覧から複数選択 |
+| リアクション | テキスト入力（子どもごと） | 選択した子どもの横に表示 |
+| タグ | タグ入力（オートコンプリート） | 入力中にサジェスト、Enter で追加 |
+| メモ | テキストエリア | 任意 |
+
+**絵本選択の UX**:
+- 本棚にある絵本をドロップダウンまたはモーダル検索で選択
+- BookDetailPage からの導線: 「読み聞かせを記録」ボタンで `picture_book_id` をプリセット
+
+**タグ入力の UX**:
+- テキスト入力中に `useSearchTags` でサジェスト表示
+- サジェストをクリック or Enter でタグ追加
+- 追加済みタグはチップ（badge）で表示、x ボタンで削除
+- 存在しないタグ名も入力可能（バックエンドで自動作成）
+
+### RecordListPage
+
+- タイムライン形式で記録を表示（日付降順）
+- フィルターパネル:
+  - 子ども（ドロップダウン）
+  - 絵本（ドロップダウンまたは検索）
+  - 期間（date_from, date_to）
+- ページネーション
+- 空状態: 「まだ読み聞かせの記録がありません」
+
+### RecordCard コンポーネント
+
+- 絵本サムネイル + タイトル
+- 読んだ日
+- 子どもの名前 + リアクション（アイコン or テキスト）
+- タグ（チップ表示）
+- メモ（省略表示）
+- クリックで詳細ページへ
+
+### RecordDetailPage
+
+- 記録の全情報を表示
+- 編集ボタン → RecordEditPage へ
+- 削除ボタン（確認ダイアログ付き）
+
+### RecordEditPage
+
+- RecordForm を編集モードで再利用
+- 既存データをフォームにプリセット
+- 更新成功時に詳細ページへリダイレクト
+
+### BookDetailPage への統合
+
+Step 4 で作成した BookDetailPage に読み聞かせ記録セクションを追加:
+
+```typescript
+// BookDetailPage 内
+const { data: records } = useRecords(familyId, { picture_book_id: bookId });
+
+// 「読み聞かせを記録する」ボタン → /records/new?book_id={bookId}
+// この絵本の記録一覧（最新数件）
+// 「すべての記録を見る」リンク → /records?picture_book_id={bookId}
+```
+
+---
+
+## 5-12. PictureBook の read_status 自動更新（検討事項）
+
+読み聞かせ記録の作成時に、紐付く絵本の `read_status` を自動更新するか:
+
+| 方式 | 説明 |
+|---|---|
+| 自動更新 | 記録が作成されたら `read_status` を `read` に変更 |
+| 手動のみ | ユーザーが明示的にステータスを変更 |
+
+→ **Phase 1 では手動のみ**。理由:
+- 「読み聞かせを記録した ≠ 読了」のケースがある（途中まで読んだ、読み聞かせ中のメモ等）
+- 自動更新のロジックが曖昧（最初の記録で `reading`、N回目で `read` 等のルールが不明確）
+- シンプルさを優先し、Phase 2 以降で検討
+
+---
+
+## 5-13. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | マイグレーション | `task migrate` | 4テーブル作成 |
+| 2 | 記録作成 | `curl -X POST .../families/{id}/records` | 201, 子ども・タグ紐付け |
+| 3 | 複数子ども + リアクション | 作成時に children 配列で指定 | 各子どもの reaction が保存 |
+| 4 | 新規タグ作成 | 存在しないタグ名で記録作成 | タグが自動作成され紐付け |
+| 5 | 記録一覧 | `curl .../families/{id}/records` | 200, ページネーション付き |
+| 6 | child_id フィルター | `?child_id=1` | 該当子どもの記録のみ |
+| 7 | picture_book_id フィルター | `?picture_book_id=1` | 該当絵本の記録のみ |
+| 8 | 日付範囲フィルター | `?date_from=...&date_to=...` | 範囲内の記録のみ |
+| 9 | 記録詳細 | `curl .../families/{id}/records/{recordId}` | 200, 全リレーション含む |
+| 10 | 記録更新 | `curl -X PUT ...` | 200, ピボット sync |
+| 11 | 記録削除 | `curl -X DELETE ...` | 200 or 204, ピボットも削除 |
+| 12 | タグ検索 | `curl /api/v1/tags?q=寝` | 200, 前方一致の候補 |
+| 13 | 認可: 他家族 | 所属していない family_id でアクセス | 403 |
+| 14 | React 記録作成フロー | RecordCreatePage で全フィールド入力 → 送信 | 一覧に反映 |
+| 15 | React 記録編集フロー | RecordEditPage で既存データ表示 → 更新 → 詳細ページへリダイレクト | 更新が反映 |
+| 16 | React タグ入力 | タグ入力でサジェスト表示 → 選択 | 正しく紐付け |
+| 16 | React BookDetailPage | 絵本詳細に記録セクション表示 | 記録一覧・追加ボタン |
+| 17 | Feature テスト | `task test` | 全テスト通過 |
+
+---
+
+## 作業順序まとめ
+
+```
+5-1.  マイグレーション (read_records, child_read_record, tags, read_record_tag)
+         ↓
+5-2.  Domain 層 (Entity, ValueObject, RepositoryInterface)
+         ↓
+5-3.  Application 層 (Command/Query Handler)
+         ↓
+5-4.  Infrastructure 層 (EloquentRepository, ServiceProvider バインド)
+         ↓
+5-5.  Eloquent Model (ReadRecord, Tag, 既存モデルへのリレーション追加)
+         ↓
+5-6.  Interface 層 (Controller, Request, Resource, Routes)
+         ↓
+5-7.  認可 (ReadRecordPolicy)
+         ↓
+5-8.  Feature テスト作成・実行
+         ↓
+5-9.  フロントエンド 型定義 + API 関数
+         ↓
+5-10. カスタムフック (useRecords, useSearchTags)
+         ↓
+5-11. ページコンポーネント (RecordList, RecordCreate, RecordDetail, BookDetailPage 統合)
+         ↓
+5-12. read_status 自動更新の検討（Phase 1 では見送り）
+         ↓
+5-13. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **Value Object の共有**: `FamilyId`, `UserId`, `ChildId`, `PictureBookId` は共有カーネル（`packages/Shared/ValueObject/`）から参照。rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照
+- **reaction は自由テキスト**: 定義済み選択肢ではなく string で保存。フロントエンドでのサジェストは Phase 2 で検討
+- **tags はグローバルスコープ**: rebuild-plan のスキーマに準拠。家族スコープではない
+- **children は最低1人必須**: 「誰に読んだか」が記録の核心情報。子どもなしの記録は許可しない
+- **タグの自動作成**: `firstOrCreate` で存在しなければ作成。ユーザーが自由にタグを作れる
+- **ピボットテーブルの sync**: 更新時に `sync()` を使い、追加・削除・変更を一括処理
+- **read_status の自動更新は見送り**: Phase 1 ではユーザーの手動操作のみ
+- **絵本削除時の cascade**: `picture_books` 削除で `read_records` も cascade 削除される設計。Step 4 の注意事項で言及した点はこの Step で確定
+- **RecordForm の再利用**: 作成（RecordCreatePage）と編集（RecordEditPage）で同一フォームコンポーネントを使う
+- **BookDetailPage からの導線**: クエリパラメータ `?book_id=` で絵本をプリセットし、記録作成への導線をスムーズにする

--- a/docs/plans/step6-invitations.md
+++ b/docs/plans/step6-invitations.md
@@ -1,0 +1,1148 @@
+# Step 6: 家族招待 (Invitations) — 詳細プラン
+
+## ゴール
+
+家族メンバーが他のユーザーをメールアドレスで招待し、招待メール内のリンクから受理することで家族に参加できる状態にする。
+招待機能は Family コンテキスト内に実装し、InvitationDomainService でドメインロジックを管理する。Mailpit で開発中のメール送受信を確認する。
+
+## 完了条件
+
+- [ ] `POST /api/v1/families/{family}/invitations` で招待メールが送信される
+- [ ] `GET /api/v1/families/{family}/invitations` で招待一覧（ステータス付き）が取得できる
+- [ ] `POST /api/v1/invitations/{token}/accept` で招待を受理し、家族に参加できる
+- [ ] `DELETE /api/v1/families/{family}/invitations/{invitation}` で招待をキャンセルできる
+- [ ] 招待トークンに有効期限があり、期限切れの招待は受理できない
+- [ ] すでに家族に所属しているユーザーを招待するとエラーが返る
+- [ ] 招待メールが Mailpit で確認できる
+- [ ] React SPA から招待送信・招待受理の一連のフローが動作する
+- [ ] Feature テストが全て通る
+
+---
+
+## 6-1. マイグレーション
+
+### `create_family_invitations_table`
+
+```php
+Schema::create('family_invitations', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('family_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('invited_by')->constrained('users')->cascadeOnDelete();
+    $table->string('email');
+    $table->string('token', 64)->unique();
+    $table->timestamp('accepted_at')->nullable();
+    $table->timestamp('expires_at');
+    $table->timestamps();
+
+    $table->index(['family_id', 'email']);
+    $table->index('token');
+});
+```
+
+### 設計判断: トークンの生成方法と長さ
+
+| 方式 | 説明 |
+|---|---|
+| UUID v4 | 36文字（ハイフン含む）。衝突リスクが極めて低い |
+| `Str::random(64)` | 64文字のランダム英数字。URL に使いやすい |
+| 署名付き URL（Laravel Signed URL） | Laravel 組み込み機能。改ざん防止付き |
+
+→ **`Str::random(64)` を採用**。理由:
+- 招待トークンは一時的なもので、署名付き URL ほどの厳密さは不要
+- DB に保存して照合するシンプルなフロー
+- URL に含めやすい文字列（英数字のみ）
+
+### 設計判断: 有効期限のデフォルト値
+
+→ **7日間**。短すぎるとメール確認が間に合わない場合があり、長すぎるとセキュリティリスク。個人・家族向けアプリとして妥当な期間。
+
+### 確認ポイント
+
+- `task migrate` で `family_invitations` テーブルが作成される
+
+---
+
+## 6-2. Family コンテキスト — Domain 層（招待関連の追加）
+
+### ディレクトリ構成（Step 3 からの追加分）
+
+```
+backend/packages/Family/
+├── Domain/
+│   ├── Entity/
+│   │   ├── Family.php          # 既存
+│   │   ├── Child.php           # 既存
+│   │   └── Invitation.php      # 新規
+│   ├── ValueObject/
+│   │   ├── ...                 # 既存
+│   │   ├── InvitationId.php    # 新規
+│   │   └── InvitationToken.php # 新規
+│   ├── Repository/
+│   │   ├── ...                 # 既存
+│   │   └── InvitationRepositoryInterface.php  # 新規
+│   └── Service/
+│       └── InvitationDomainService.php        # 新規
+```
+
+> `FamilyId`, `UserId`, `Email` は共有カーネル（`packages/Shared/ValueObject/`）から参照。詳細は rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照。
+
+### Domain Entity: `Invitation`
+
+```php
+namespace Packages\Family\Domain\Entity;
+
+final class Invitation
+{
+    public function __construct(
+        private readonly ?InvitationId $id,
+        private readonly FamilyId $familyId,
+        private readonly UserId $invitedBy,
+        private readonly Email $email,
+        private readonly InvitationToken $token,
+        private ?DateTimeImmutable $acceptedAt,
+        private readonly DateTimeImmutable $expiresAt,
+    ) {}
+
+    public static function create(
+        FamilyId $familyId,
+        UserId $invitedBy,
+        Email $email,
+        InvitationToken $token,
+        DateTimeImmutable $expiresAt,
+    ): self {
+        return new self(
+            null, $familyId, $invitedBy, $email, $token, null, $expiresAt,
+        );
+    }
+
+    public function isExpired(): bool
+    {
+        return new DateTimeImmutable() > $this->expiresAt;
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this->acceptedAt !== null;
+    }
+
+    public function isPending(): bool
+    {
+        return !$this->isAccepted() && !$this->isExpired();
+    }
+
+    public function accept(): void
+    {
+        if ($this->isExpired()) {
+            throw new InvitationExpiredException();
+        }
+        if ($this->isAccepted()) {
+            throw new InvitationAlreadyAcceptedException();
+        }
+        $this->acceptedAt = new DateTimeImmutable();
+    }
+
+    // Getter, reconstruct メソッド
+}
+```
+
+### Value Objects
+
+| クラス | 内容 |
+|---|---|
+| `InvitationId` | 正の整数 |
+| `InvitationToken` | 64文字の英数字文字列。生成用ファクトリメソッド付き |
+
+### InvitationToken
+
+```php
+namespace Packages\Family\Domain\ValueObject;
+
+use Illuminate\Support\Str;
+
+final class InvitationToken
+{
+    private function __construct(
+        private readonly string $value,
+    ) {
+        if (strlen($value) !== 64) {
+            throw new InvalidArgumentException('Token must be 64 characters.');
+        }
+    }
+
+    public static function generate(): self
+    {
+        return new self(Str::random(64));
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}
+```
+
+### Domain Exceptions
+
+```
+backend/packages/Family/
+└── Domain/
+    └── Exception/
+        ├── InvitationExpiredException.php
+        ├── InvitationAlreadyAcceptedException.php
+        └── UserAlreadyInFamilyException.php
+```
+
+### Repository Interface
+
+```php
+namespace Packages\Family\Domain\Repository;
+
+interface InvitationRepositoryInterface
+{
+    public function findById(InvitationId $id): ?Invitation;
+    public function findByToken(InvitationToken $token): ?Invitation;
+    public function findPendingByFamilyIdAndEmail(FamilyId $familyId, Email $email): ?Invitation;
+    public function findByFamilyId(FamilyId $familyId): array;
+    public function save(Invitation $invitation): Invitation;
+    public function delete(InvitationId $id): void;
+}
+```
+
+### InvitationDomainService
+
+招待に関するドメインロジックを集約:
+
+```php
+namespace Packages\Family\Domain\Service;
+
+final class InvitationDomainService
+{
+    public function __construct(
+        private readonly InvitationRepositoryInterface $invitationRepository,
+    ) {}
+
+    /**
+     * 招待を作成できるか検証し、Invitation エンティティを生成する
+     */
+    public function createInvitation(
+        FamilyId $familyId,
+        UserId $invitedBy,
+        Email $email,
+    ): Invitation {
+        // 同じ家族・同じメールアドレスで未処理の招待が既にあるか
+        $existing = $this->invitationRepository->findPendingByFamilyIdAndEmail($familyId, $email);
+        if ($existing !== null) {
+            throw new DuplicateInvitationException();
+        }
+
+        $token = InvitationToken::generate();
+        $expiresAt = new DateTimeImmutable('+7 days');
+
+        return Invitation::create($familyId, $invitedBy, $email, $token, $expiresAt);
+    }
+}
+```
+
+### 設計判断: ドメインサービスを使う理由
+
+招待作成は以下の複合的な検証が必要:
+- 同じメールへの重複招待チェック（Repository 参照）
+- トークン生成
+- 有効期限の決定
+
+これらは Invitation Entity 単体では完結しないため、DomainService に切り出す。
+
+---
+
+## 6-3. Family コンテキスト — Application 層（招待関連の追加）
+
+### ディレクトリ構成
+
+```
+backend/packages/Family/
+├── Application/
+│   ├── Command/
+│   │   ├── ...                        # 既存 (CreateFamily, AddChild 等)
+│   │   ├── SendInvitation/
+│   │   │   ├── SendInvitationCommand.php
+│   │   │   └── SendInvitationHandler.php
+│   │   ├── AcceptInvitation/
+│   │   │   ├── AcceptInvitationCommand.php
+│   │   │   └── AcceptInvitationHandler.php
+│   │   └── CancelInvitation/
+│   │       ├── CancelInvitationCommand.php
+│   │       └── CancelInvitationHandler.php
+│   └── Query/
+│       ├── ...                        # 既存
+│       └── ListInvitations/
+│           ├── ListInvitationsQuery.php
+│           └── ListInvitationsHandler.php
+```
+
+### SendInvitation
+
+**`SendInvitationCommand`** (DTO):
+```php
+final class SendInvitationCommand
+{
+    public function __construct(
+        public readonly int $familyId,
+        public readonly int $invitedByUserId,
+        public readonly string $email,
+    ) {}
+}
+```
+
+**`SendInvitationHandler`**:
+1. 招待先メールアドレスのユーザーが既に同家族に所属していないか確認
+2. `InvitationDomainService::createInvitation()` で招待エンティティ生成（重複チェック含む）
+3. `InvitationRepository::save()` で永続化
+4. `InvitationMail` を送信
+5. 作成された Invitation を返却
+
+### AcceptInvitation
+
+**`AcceptInvitationCommand`**:
+```php
+final class AcceptInvitationCommand
+{
+    public function __construct(
+        public readonly string $token,
+        public readonly int $userId,
+    ) {}
+}
+```
+
+**`AcceptInvitationHandler`**:
+1. `InvitationRepository::findByToken()` でトークンから招待を取得
+2. 招待が存在しない → 404 相当の例外
+3. `Invitation::accept()` を呼ぶ（期限切れ・受理済みチェックは Entity 内）
+4. 受理ユーザーが既に別の家族に所属していないか確認
+5. ユーザーの `family_id` を招待された家族に更新
+6. `InvitationRepository::save()` で `accepted_at` を永続化
+7. 受理結果を返却
+
+### CancelInvitation
+
+**`CancelInvitationHandler`**:
+1. `InvitationRepository::findById()` で取得
+2. 受理済みでないことを確認
+3. `InvitationRepository::delete()` で削除
+
+### ListInvitations（Query）
+
+**`ListInvitationsHandler`**:
+- Eloquent を直接使って家族の招待一覧を取得
+- ステータス情報（pending / accepted / expired）を付与
+
+### 設計判断: AcceptInvitation 時の User.family_id 更新
+
+Step 3 の CreateFamily と同様、コンテキスト横断の操作。Handler 内で直接 Eloquent User Model 経由で更新する。
+
+### 設計判断: 招待受理にログインは必要か
+
+| 方式 | 説明 |
+|---|---|
+| ログイン必須 | 受理時に認証済みユーザーの family_id を更新 |
+| ログイン不要 + 新規登録導線 | トークンだけで受理。未登録ユーザーには登録画面を表示 |
+
+→ **ログイン必須を採用**。理由:
+- 認証済みユーザーと招待を紐付ける必要がある（誰が受理したか明確）
+- 未登録ユーザーには「先にアカウント登録してからこのリンクを開いてください」と案内
+- Phase 1 ではシンプルなフローを優先
+
+**フロー**:
+```
+メール内リンク → /invitations/{token}/accept
+  ├─ ログイン済み → 受理 API 呼び出し → ダッシュボードへ
+  └─ 未ログイン → ログインページへリダイレクト（リターン URL 付き）
+```
+
+---
+
+## 6-4. Family コンテキスト — Infrastructure 層（招待関連の追加）
+
+### ディレクトリ構成
+
+```
+backend/packages/Family/
+└── Infrastructure/
+    ├── Repository/
+    │   ├── ...                            # 既存
+    │   └── EloquentInvitationRepository.php  # 新規
+    └── Mail/
+        └── InvitationMail.php             # 新規
+```
+
+### EloquentInvitationRepository
+
+```php
+namespace Packages\Family\Infrastructure\Repository;
+
+final class EloquentInvitationRepository implements InvitationRepositoryInterface
+{
+    public function findByToken(InvitationToken $token): ?Invitation
+    {
+        $model = EloquentFamilyInvitation::where('token', $token->value())->first();
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function findPendingByFamilyIdAndEmail(FamilyId $familyId, Email $email): ?Invitation
+    {
+        $model = EloquentFamilyInvitation::where('family_id', $familyId->value())
+            ->where('email', $email->value())
+            ->whereNull('accepted_at')
+            ->where('expires_at', '>', now())
+            ->first();
+        return $model ? $this->toDomainEntity($model) : null;
+    }
+
+    public function findByFamilyId(FamilyId $familyId): array
+    {
+        return EloquentFamilyInvitation::where('family_id', $familyId->value())
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn ($model) => $this->toDomainEntity($model))
+            ->toArray();
+    }
+
+    public function save(Invitation $invitation): Invitation
+    {
+        if ($invitation->id() === null) {
+            $model = EloquentFamilyInvitation::create([
+                'family_id' => $invitation->familyId()->value(),
+                'invited_by' => $invitation->invitedBy()->value(),
+                'email' => $invitation->email()->value(),
+                'token' => $invitation->token()->value(),
+                'accepted_at' => $invitation->acceptedAt(),
+                'expires_at' => $invitation->expiresAt(),
+            ]);
+        } else {
+            $model = EloquentFamilyInvitation::findOrFail($invitation->id()->value());
+            $model->update([
+                'accepted_at' => $invitation->acceptedAt(),
+            ]);
+        }
+        return $this->toDomainEntity($model);
+    }
+
+    public function delete(InvitationId $id): void
+    {
+        EloquentFamilyInvitation::destroy($id->value());
+    }
+
+    private function toDomainEntity(EloquentFamilyInvitation $model): Invitation { /* ... */ }
+}
+```
+
+### InvitationMail
+
+```php
+namespace Packages\Family\Infrastructure\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class InvitationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        private readonly string $familyName,
+        private readonly string $inviterName,
+        private readonly string $acceptUrl,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "{$this->familyName} への招待",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.invitation',
+            with: [
+                'familyName' => $this->familyName,
+                'inviterName' => $this->inviterName,
+                'acceptUrl' => $this->acceptUrl,
+            ],
+        );
+    }
+}
+```
+
+### メールテンプレート
+
+`backend/resources/views/mail/invitation.blade.php`:
+
+```blade
+<x-mail::message>
+# {{ $familyName }} に招待されました
+
+{{ $inviterName }} さんから「{{ $familyName }}」への招待が届きました。
+
+以下のボタンをクリックして招待を受け入れてください。
+
+<x-mail::button :url="$acceptUrl">
+招待を受け入れる
+</x-mail::button>
+
+このリンクは7日間有効です。
+
+心当たりがない場合は、このメールを無視してください。
+
+{{ config('app.name') }}
+</x-mail::message>
+```
+
+### 招待受理 URL の構成
+
+```
+{FRONTEND_URL}/invitations/{token}/accept
+```
+
+- フロントエンドの URL。メールリンクは React SPA のルートを指す
+- React 側でトークンを取得し、API に受理リクエストを送る
+
+### ServiceProvider でのバインド
+
+```php
+$this->app->bind(InvitationRepositoryInterface::class, EloquentInvitationRepository::class);
+```
+
+---
+
+## 6-5. Eloquent Model
+
+### `app/Models/FamilyInvitation.php`（新規）
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FamilyInvitation extends Model
+{
+    protected $fillable = [
+        'family_id',
+        'invited_by',
+        'email',
+        'token',
+        'accepted_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'accepted_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(Family::class);
+    }
+
+    public function invitedByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'invited_by');
+    }
+}
+```
+
+### `app/Models/Family.php`（リレーション追加）
+
+```php
+public function invitations(): HasMany
+{
+    return $this->hasMany(FamilyInvitation::class);
+}
+```
+
+---
+
+## 6-6. Interface 層 — Controller, Request, Resource, Routes
+
+### ディレクトリ構成
+
+```
+backend/app/Http/
+├── Controllers/Api/
+│   └── InvitationController.php
+├── Requests/
+│   └── SendInvitationRequest.php
+└── Resources/
+    └── InvitationResource.php
+```
+
+### InvitationController
+
+```php
+class InvitationController extends Controller
+{
+    // POST /api/v1/families/{family}/invitations
+    public function store(SendInvitationRequest $request, Family $family, SendInvitationHandler $handler)
+
+    // GET /api/v1/families/{family}/invitations
+    public function index(Family $family, ListInvitationsHandler $handler)
+
+    // DELETE /api/v1/families/{family}/invitations/{invitation}
+    public function destroy(Family $family, FamilyInvitation $invitation, CancelInvitationHandler $handler)
+
+    // POST /api/v1/invitations/{token}/accept
+    public function accept(string $token, AcceptInvitationHandler $handler)
+}
+```
+
+### FormRequest バリデーション
+
+**`SendInvitationRequest`**:
+| フィールド | ルール |
+|---|---|
+| `email` | `required`, `string`, `email`, `max:255` |
+
+**追加バリデーション**:
+- 招待先メールが自分自身ではないこと
+- 招待先ユーザーが既に同じ家族に所属していないこと（ユーザーが存在する場合）
+
+```php
+public function withValidator($validator)
+{
+    $validator->after(function ($validator) {
+        // 自分自身への招待を防止
+        if ($this->email === $this->user()->email) {
+            $validator->errors()->add('email', '自分自身を招待することはできません。');
+        }
+
+        // 既に同家族のメンバーか確認
+        $family = $this->route('family');
+        $existingUser = User::where('email', $this->email)->first();
+        if ($existingUser && $existingUser->family_id === $family->id) {
+            $validator->errors()->add('email', 'このユーザーは既にこの家族のメンバーです。');
+        }
+    });
+}
+```
+
+### API Resource
+
+**`InvitationResource`**:
+```json
+{
+  "id": 1,
+  "email": "hanako@example.com",
+  "status": "pending",
+  "invited_by": {
+    "id": 1,
+    "name": "太郎"
+  },
+  "expires_at": "2026-03-15T00:00:00.000000Z",
+  "accepted_at": null,
+  "created_at": "2026-03-08T00:00:00.000000Z"
+}
+```
+
+`status` フィールドは Resource 内で算出:
+```php
+public function toArray($request): array
+{
+    return [
+        // ...
+        'status' => $this->getStatus(),
+    ];
+}
+
+private function getStatus(): string
+{
+    if ($this->accepted_at !== null) {
+        return 'accepted';
+    }
+    if ($this->expires_at->isPast()) {
+        return 'expired';
+    }
+    return 'pending';
+}
+```
+
+### API レスポンス形式
+
+**招待送信成功 (201)**:
+```json
+{
+  "message": "招待メールを送信しました。",
+  "invitation": { /* InvitationResource */ }
+}
+```
+
+**招待受理成功 (200)**:
+```json
+{
+  "message": "家族に参加しました。",
+  "family": { /* FamilyResource */ }
+}
+```
+
+**招待期限切れ (410 Gone)**:
+```json
+{
+  "message": "この招待は期限切れです。"
+}
+```
+
+**招待受理済み (409 Conflict)**:
+```json
+{
+  "message": "この招待は既に受理されています。"
+}
+```
+
+### ルート定義 (`routes/api.php`)
+
+```php
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    // ... 既存ルート ...
+
+    // 招待（家族に紐付く操作）
+    Route::prefix('/families/{family}/invitations')->group(function () {
+        Route::post('/', [InvitationController::class, 'store']);
+        Route::get('/', [InvitationController::class, 'index']);
+        Route::delete('/{invitation}', [InvitationController::class, 'destroy']);
+    });
+
+    // 招待受理（家族に紐付かない。トークンで特定）
+    Route::post('/invitations/{token}/accept', [InvitationController::class, 'accept']);
+});
+```
+
+---
+
+## 6-7. 認可
+
+招待関連の認可は既存の `FamilyPolicy` を再利用:
+
+- `store`, `index`, `destroy`: `FamilyPolicy::view` で家族所属チェック
+- `accept`: 認証済みであれば誰でも可（トークンが正しければ受理可能）
+
+`destroy` の追加チェック:
+- 招待が指定された家族に属しているか（`scopeBindings` or 手動チェック）
+- 受理済みの招待は削除不可
+
+---
+
+## 6-8. 例外ハンドリング
+
+Domain 例外を HTTP レスポンスにマッピング:
+
+```php
+// app/Exceptions/Handler.php or bootstrap/app.php (Laravel 11)
+use Packages\Family\Domain\Exception\InvitationExpiredException;
+use Packages\Family\Domain\Exception\InvitationAlreadyAcceptedException;
+use Packages\Family\Domain\Exception\UserAlreadyInFamilyException;
+use Packages\Family\Domain\Exception\DuplicateInvitationException;
+
+$exceptions->render(function (InvitationExpiredException $e) {
+    return response()->json(['message' => 'この招待は期限切れです。'], 410);
+});
+
+$exceptions->render(function (InvitationAlreadyAcceptedException $e) {
+    return response()->json(['message' => 'この招待は既に受理されています。'], 409);
+});
+
+$exceptions->render(function (UserAlreadyInFamilyException $e) {
+    return response()->json(['message' => 'このユーザーは既に家族に所属しています。'], 409);
+});
+
+$exceptions->render(function (DuplicateInvitationException $e) {
+    return response()->json(['message' => 'このメールアドレスへの招待は既に送信されています。'], 409);
+});
+```
+
+### 設計判断: 例外マッピングの場所
+
+| 方式 | 説明 |
+|---|---|
+| Handler / bootstrap | 全例外を一箇所で管理 |
+| Controller 内で try-catch | 各 Controller で個別にハンドリング |
+
+→ **Handler / bootstrap で一括マッピング**。Domain 例外は複数の Controller から投げられる可能性があり、一箇所で管理した方が一貫性がある。
+
+---
+
+## 6-9. Feature テスト
+
+### テストファイル
+
+```
+backend/tests/Feature/
+└── Family/
+    ├── ...                         # 既存 (Step 3)
+    ├── SendInvitationTest.php      # 新規
+    ├── ListInvitationsTest.php     # 新規
+    ├── AcceptInvitationTest.php    # 新規
+    └── CancelInvitationTest.php   # 新規
+```
+
+### テストケース一覧
+
+**SendInvitationTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に招待を送信 | 201, メール送信、DB に招待レコード |
+| 2 | 自分自身のメールアドレスを指定 | 422 |
+| 3 | 既にメンバーのユーザーを招待 | 422 |
+| 4 | 同じメールに重複招待 | 409 |
+| 5 | 所属していない家族から招待 | 403 |
+| 6 | 未登録メールアドレスへの招待 | 201（メールは送信される。受理時に登録が必要） |
+
+> メール送信のアサーション: `Mail::fake()` + `Mail::assertSent(InvitationMail::class)`
+
+**ListInvitationsTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 招待一覧を取得 | 200, status 付き |
+| 2 | pending / accepted / expired が正しく返る | ステータス算出の検証 |
+| 3 | 所属していない家族の招待一覧 | 403 |
+
+**AcceptInvitationTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に招待を受理 | 200, ユーザーの family_id が更新 |
+| 2 | 期限切れトークン | 410 |
+| 3 | 既に受理済みのトークン | 409 |
+| 4 | 存在しないトークン | 404 |
+| 5 | 既に別の家族に所属しているユーザーが受理 | 409 |
+| 6 | 未認証でアクセス | 401 |
+
+**CancelInvitationTest**:
+| # | テストケース | 期待結果 |
+|---|---|---|
+| 1 | 正常に招待をキャンセル | 200 or 204 |
+| 2 | 受理済みの招待をキャンセル | 409 or 422 |
+| 3 | 所属していない家族の招待をキャンセル | 403 |
+
+### メール送信のテスト
+
+```php
+use Illuminate\Support\Facades\Mail;
+
+Mail::fake();
+
+// 招待 API を呼び出し
+$response = $this->postJson("/api/v1/families/{$family->id}/invitations", [
+    'email' => 'hanako@example.com',
+]);
+
+$response->assertCreated();
+
+Mail::assertSent(InvitationMail::class, function ($mail) {
+    return $mail->hasTo('hanako@example.com');
+});
+```
+
+---
+
+## 6-10. フロントエンド — API 関数・型定義
+
+### `src/types/invitation.ts`
+
+```typescript
+export interface Invitation {
+  id: number;
+  email: string;
+  status: 'pending' | 'accepted' | 'expired';
+  invited_by: { id: number; name: string };
+  expires_at: string;
+  accepted_at: string | null;
+  created_at: string;
+}
+```
+
+### `src/api/invitations.ts`
+
+```typescript
+import apiClient from './client';
+
+export const sendInvitation = (familyId: number, data: { email: string }) =>
+  apiClient.post(`/families/${familyId}/invitations`, data);
+
+export const getInvitations = (familyId: number) =>
+  apiClient.get(`/families/${familyId}/invitations`);
+
+export const cancelInvitation = (familyId: number, invitationId: number) =>
+  apiClient.delete(`/families/${familyId}/invitations/${invitationId}`);
+
+export const acceptInvitation = (token: string) =>
+  apiClient.post(`/invitations/${token}/accept`);
+```
+
+---
+
+## 6-11. フロントエンド — カスタムフック
+
+### `src/hooks/useInvitations.ts`
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useInvitations = (familyId: number) => {
+  return useQuery({
+    queryKey: ['invitations', familyId],
+    queryFn: () => getInvitations(familyId),
+  });
+};
+
+export const useSendInvitation = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { email: string }) => sendInvitation(familyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['invitations', familyId] });
+    },
+  });
+};
+
+export const useCancelInvitation = (familyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (invitationId: number) => cancelInvitation(familyId, invitationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['invitations', familyId] });
+    },
+  });
+};
+
+export const useAcceptInvitation = () => {
+  return useMutation({
+    mutationFn: (token: string) => acceptInvitation(token),
+    // onSuccess で AuthContext の user を再取得（family_id が変わるため）
+  });
+};
+```
+
+---
+
+## 6-12. フロントエンド — ページコンポーネント
+
+### ルーティング構成（Step 5 からの追加）
+
+```typescript
+<Routes>
+  {/* 公開ルート */}
+  <Route path="/login" element={<LoginPage />} />
+  <Route path="/register" element={<RegisterPage />} />
+
+  {/* 保護ルート */}
+  <Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+    <Route path="/" element={<DashboardPage />} />
+    {/* ... 既存ルート ... */}
+
+    {/* Step 6 で追加 */}
+    <Route path="/invitations/:token/accept" element={<AcceptInvitationPage />} />
+  </Route>
+</Routes>
+```
+
+### FamilySettingsPage への統合（InviteMemberForm + InvitationList）
+
+Step 3 で作成した FamilySettingsPage に招待セクションを追加:
+
+```
+FamilySettingsPage
+├── 家族名編集フォーム        (既存)
+├── メンバー一覧              (既存)
+├── 子ども管理セクション       (既存)
+└── 招待セクション             (Step 6 追加)
+    ├── InviteMemberForm      メールアドレス入力 + 送信ボタン
+    └── InvitationList        招待一覧（ステータスバッジ + キャンセルボタン）
+```
+
+### InviteMemberForm
+
+- メールアドレス入力フィールド（React Hook Form）
+- 送信ボタン
+- 送信成功時にトースト通知「招待メールを送信しました」
+- エラー表示: 重複招待、既にメンバー、自分自身等
+
+### InvitationList
+
+- 招待一覧を表示
+- 各招待のステータスバッジ:
+  - `pending`: 黄色「招待中」
+  - `accepted`: 緑「受理済み」
+  - `expired`: グレー「期限切れ」
+- `pending` の招待にキャンセルボタン（確認ダイアログ付き）
+- 招待先メールアドレス、招待日、有効期限を表示
+
+### AcceptInvitationPage
+
+メールリンクからアクセスされるページ:
+
+```typescript
+const AcceptInvitationPage = () => {
+  const { token } = useParams<{ token: string }>();
+  const { mutate: accept, isPending, isSuccess, isError, error } = useAcceptInvitation();
+  const { refreshUser } = useAuth();
+
+  useEffect(() => {
+    if (token) {
+      accept(token, {
+        onSuccess: async (data) => {
+          await refreshUser();  // family_id を反映
+          // 成功メッセージ表示後、ダッシュボードへ遷移
+        },
+      });
+    }
+  }, [token]);
+
+  if (isPending) return <p>招待を受理しています...</p>;
+  if (isSuccess) return <p>家族に参加しました！リダイレクトしています...</p>;
+  if (isError) return <ErrorDisplay error={error} />;
+
+  return null;
+};
+```
+
+**エラー表示**:
+| ステータスコード | 表示メッセージ |
+|---|---|
+| 404 | 「この招待は見つかりませんでした。」 |
+| 410 | 「この招待は期限切れです。家族のメンバーに再度招待を依頼してください。」 |
+| 409 (already accepted) | 「この招待は既に受理されています。」 |
+| 409 (already in family) | 「あなたは既に家族に所属しています。」 |
+
+### 設計判断: 招待受理ページのアクセスフロー
+
+```
+メールリンク: {FRONTEND_URL}/invitations/{token}/accept
+  │
+  ├─ ログイン済み
+  │   └─ AcceptInvitationPage が表示 → 自動的に受理 API 呼び出し
+  │
+  └─ 未ログイン
+      └─ ProtectedRoute により /login にリダイレクト
+         └─ ログイン後、元の URL に戻る（リターン URL）
+```
+
+**リターン URL の実装**:
+ProtectedRoute でリダイレクト時に現在の URL を state に含める:
+
+```typescript
+// ProtectedRoute
+if (!user) {
+  return <Navigate to="/login" state={{ from: location }} replace />;
+}
+
+// LoginPage - ログイン成功後
+const from = location.state?.from?.pathname || '/';
+navigate(from, { replace: true });
+```
+
+---
+
+## 6-13. Mailpit での確認
+
+### 確認手順
+
+1. `task up` でコンテナ起動
+2. API で招待を送信
+3. ブラウザで `http://localhost:8025` を開く
+4. 受信メール一覧に招待メールが表示される
+5. メール本文の「招待を受け入れる」リンクを確認
+6. リンク URL が `{FRONTEND_URL}/invitations/{token}/accept` 形式であること
+
+### Laravel メール設定の確認
+
+`backend/.env` が Mailpit を指していること（Step 1 で設定済み）:
+
+```env
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_FROM_ADDRESS="noreply@picturebooklog.local"
+MAIL_FROM_NAME="${APP_NAME}"
+```
+
+---
+
+## 6-14. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | マイグレーション | `task migrate` | family_invitations テーブル作成 |
+| 2 | 招待送信 API | `curl -X POST .../families/{id}/invitations` | 201, DB にレコード |
+| 3 | メール送信 | Mailpit UI (localhost:8025) | 招待メールが受信されている |
+| 4 | メール内リンク | メール本文を確認 | 正しい URL 形式 |
+| 5 | 招待一覧 | `curl .../families/{id}/invitations` | 200, ステータス付き |
+| 6 | 重複招待チェック | 同じメールで再度 POST | 409 |
+| 7 | 自分自身への招待 | 自分のメールで POST | 422 |
+| 8 | 既にメンバーへの招待 | 同家族ユーザーのメールで POST | 422 |
+| 9 | 招待受理 | `curl -X POST .../invitations/{token}/accept` | 200, family_id 更新 |
+| 10 | 期限切れ受理 | 期限切れトークンで受理 | 410 |
+| 11 | 二重受理 | 受理済みトークンで再度受理 | 409 |
+| 12 | 別家族所属ユーザーの受理 | 既に別の家族に所属しているユーザーで受理 | 409 |
+| 13 | 招待キャンセル | `curl -X DELETE .../families/{id}/invitations/{invId}` | 200 or 204 |
+| 13 | 認可: 他家族 | 所属していない family_id でアクセス | 403 |
+| 14 | React 招待送信 | FamilySettingsPage で招待送信 | 招待一覧に反映 + メール送信 |
+| 15 | React 招待受理 | メールリンクから AcceptInvitationPage | 家族に参加、ダッシュボードへ |
+| 16 | React 未ログイン受理 | 未ログインでリンクアクセス | ログイン後にリダイレクト |
+| 17 | Feature テスト | `task test` | 全テスト通過 |
+
+---
+
+## 作業順序まとめ
+
+```
+6-1.  マイグレーション (family_invitations)
+         ↓
+6-2.  Domain 層 (Entity, ValueObject, RepositoryInterface, DomainService, Exceptions)
+         ↓
+6-3.  Application 層 (Command/Query Handler)
+         ↓
+6-4.  Infrastructure 層 (EloquentRepository, InvitationMail, Blade テンプレート)
+         ↓
+6-5.  Eloquent Model (FamilyInvitation, Family リレーション追加)
+         ↓
+6-6.  Interface 層 (Controller, Request, Resource, Routes)
+         ↓
+6-7.  認可 (FamilyPolicy 再利用)
+         ↓
+6-8.  例外ハンドリング (Domain 例外 → HTTP レスポンスマッピング)
+         ↓
+6-9.  Feature テスト作成・実行 (Mail::fake 含む)
+         ↓
+6-10. フロントエンド 型定義 + API 関数
+         ↓
+6-11. カスタムフック (useInvitations, useAcceptInvitation)
+         ↓
+6-12. ページコンポーネント (FamilySettingsPage 統合, AcceptInvitationPage)
+         ↓
+6-13. Mailpit での E2E 確認
+         ↓
+6-14. 疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **Value Object の共有**: `FamilyId`, `UserId`, `Email` は共有カーネル（`packages/Shared/ValueObject/`）から参照。rebuild-plan の「コンテキスト間の Value Object 共有方針」を参照
+- **トークン生成**: `Str::random(64)` でシンプルに。署名付き URL は不採用
+- **有効期限**: 7日間。`Invitation::isExpired()` で Entity 内でチェック
+- **招待受理にはログインが必須**: 未登録ユーザーは先にアカウント登録が必要。メール内に案内を記載
+- **リターン URL**: ProtectedRoute の `state.from` でログイン後に招待受理ページへ戻す
+- **既に家族に所属しているユーザーの受理**: 409 を返す。Phase 1 では家族脱退機能がないため、別家族への移動は不可
+- **DomainService の導入**: 招待作成は重複チェック + トークン生成 + 有効期限設定の複合ロジックのため、Entity 単体ではなく DomainService で管理
+- **例外マッピング**: Domain 例外を Handler/bootstrap で HTTP ステータスに一括変換。Controller の try-catch ではなく宣言的に管理
+- **メールの非同期送信**: Phase 1 では `QUEUE_CONNECTION=sync` のため同期送信。将来的にキュー化する場合は `ShouldQueue` インターフェースを追加するだけで対応可能
+- **期限切れ招待の削除**: 自動削除（スケジュールタスク）は Phase 1 では実装しない。一覧で `expired` ステータスとして表示するのみ

--- a/docs/plans/step7-finishing.md
+++ b/docs/plans/step7-finishing.md
@@ -1,0 +1,620 @@
+# Step 7: 仕上げ — 詳細プラン
+
+## ゴール
+
+Step 2〜6 で実装した機能を UX・品質・運用の観点で仕上げ、本番リリース可能な状態にする。
+エラーハンドリング、ローディング表示、空状態、レスポンシブ対応、デモデータ、ドキュメントを整備する。
+
+## 完了条件
+
+- [ ] React のグローバルエラーバウンダリが機能し、未処理エラーでアプリがクラッシュしない
+- [ ] 全ページでローディングスケルトンが表示される
+- [ ] データが空の状態でフレンドリーなメッセージと次のアクション導線が表示される
+- [ ] モバイル・タブレット・デスクトップでレイアウトが崩れない
+- [ ] `task fresh` でデモデータが投入され、一通りの操作を確認できる
+- [ ] README に環境構築手順・技術スタック・アーキテクチャ概要が記載されている
+- [ ] 全 Feature テストが通る
+
+---
+
+## 7-1. グローバルエラーバウンダリ (React)
+
+### ErrorBoundary コンポーネント
+
+React の `ErrorBoundary` でレンダリング中の未処理エラーをキャッチし、フォールバック UI を表示する。
+
+```typescript
+// src/components/ErrorBoundary.tsx
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <ErrorFallback onRetry={() => this.setState({ hasError: false, error: null })} />;
+    }
+    return this.props.children;
+  }
+}
+```
+
+### ErrorFallback コンポーネント
+
+```typescript
+// src/components/ErrorFallback.tsx
+const ErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="error-fallback">
+    <h2>予期しないエラーが発生しました</h2>
+    <p>申し訳ありません。ページの再読み込みをお試しください。</p>
+    <button onClick={onRetry}>再試行</button>
+    <button onClick={() => window.location.href = '/'}>トップに戻る</button>
+  </div>
+);
+```
+
+### 適用箇所
+
+```typescript
+// src/App.tsx
+<ErrorBoundary>
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  </QueryClientProvider>
+</ErrorBoundary>
+```
+
+### API エラーのグローバルハンドリング
+
+TanStack Query の `QueryClient` でグローバルエラーコールバックを設定:
+
+```typescript
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: {
+      onError: (error) => {
+        // 汎用エラー通知（トースト等）
+        if (isAxiosError(error) && error.response?.status === 500) {
+          toast.error('サーバーエラーが発生しました。しばらくしてから再度お試しください。');
+        }
+      },
+    },
+  },
+});
+```
+
+### 設計判断: エラー通知の方式
+
+| 方式 | 説明 |
+|---|---|
+| トースト通知 | 画面隅に一時的に表示。操作の邪魔にならない |
+| インライン表示 | フォーム直下等に表示。バリデーションエラーに適する |
+| フルページフォールバック | ErrorBoundary 用。致命的エラーのみ |
+
+→ **3つを併用**:
+- **バリデーションエラー (422)**: フォーム内のインライン表示（既に Step 2〜6 で実装済み）
+- **サーバーエラー (500)、ネットワークエラー**: トースト通知
+- **レンダリングエラー**: ErrorBoundary のフルページフォールバック
+
+トースト通知ライブラリ: `react-hot-toast`（軽量、カスタマイズ容易）
+
+```bash
+docker compose exec frontend npm install react-hot-toast
+```
+
+---
+
+## 7-2. ローディングスケルトン
+
+### 方針
+
+データ取得中に空白画面やスピナーだけでなく、コンテンツの形状を模したスケルトン UI を表示する。
+
+### 対象ページと表示内容
+
+| ページ | スケルトン内容 |
+|---|---|
+| BookSearchPage | 検索結果のカード型スケルトン（検索実行中） |
+| BookshelfPage | BookCard のグリッド型スケルトン（サムネイル + テキスト行） |
+| BookDetailPage | サムネイル + テキストブロック |
+| RecordListPage | RecordCard のリスト型スケルトン |
+| FamilySettingsPage | テキストブロック + リスト |
+| DashboardPage | カード型スケルトン群 |
+
+### 実装方法
+
+CSS アニメーションによるシンプルなスケルトン:
+
+```typescript
+// src/components/Skeleton.tsx
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+}
+
+const Skeleton = ({ width = '100%', height = '1rem', borderRadius = '4px' }: SkeletonProps) => (
+  <div
+    className="skeleton"
+    style={{ width, height, borderRadius }}
+  />
+);
+```
+
+```css
+/* src/styles/skeleton.css */
+.skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+### 各ページ用スケルトンコンポーネント
+
+```typescript
+// src/components/BookCardSkeleton.tsx
+const BookCardSkeleton = () => (
+  <div className="book-card-skeleton">
+    <Skeleton width="100%" height="200px" />        {/* サムネイル */}
+    <Skeleton width="80%" height="1rem" />           {/* タイトル */}
+    <Skeleton width="60%" height="0.875rem" />       {/* 著者 */}
+  </div>
+);
+
+// src/components/BookshelfSkeleton.tsx
+const BookshelfSkeleton = () => (
+  <div className="bookshelf-grid">
+    {Array.from({ length: 8 }).map((_, i) => (
+      <BookCardSkeleton key={i} />
+    ))}
+  </div>
+);
+```
+
+### TanStack Query との統合
+
+```typescript
+const { data, isLoading } = useBooks(familyId, params);
+
+if (isLoading) return <BookshelfSkeleton />;
+```
+
+### 設計判断: スケルトン vs スピナー
+
+| 方式 | 適するケース |
+|---|---|
+| スケルトン | 初回読み込み、ページ遷移時 |
+| スピナー | ボタンクリック後の短い待機（送信中等） |
+
+→ **データフェッチにはスケルトン、アクション実行にはボタン内スピナー**。
+ボタンスピナーは `isPending` を使って表示:
+
+```typescript
+<button disabled={isPending}>
+  {isPending ? '送信中...' : '保存'}
+</button>
+```
+
+---
+
+## 7-3. 空状態のフレンドリーメッセージ
+
+### 方針
+
+データが空の状態で「何もありません」ではなく、次のアクションを促すメッセージと導線を表示する。
+
+### 各ページの空状態
+
+| ページ | 空状態メッセージ | アクション導線 |
+|---|---|---|
+| BookshelfPage | まだ絵本が登録されていません | 「絵本を探す」ボタン → BookSearchPage |
+| RecordListPage | まだ読み聞かせの記録がありません | 「記録をつける」ボタン → RecordCreatePage |
+| FamilySettings メンバー | あなただけのメンバーです | 「家族を招待する」ボタン → 招待フォームにフォーカス |
+| FamilySettings 子ども | まだ子どもが登録されていません | 「子どもを追加する」ボタン → ChildForm |
+| RecordListPage (フィルター結果) | 条件に一致する記録がありません | 「フィルターをクリア」ボタン |
+| BookshelfPage (フィルター結果) | このステータスの絵本はありません | 「すべて表示」タブに切り替え |
+| FamilySettings 招待 | まだ招待を送っていません | 「メンバーを招待する」フォームへのガイド |
+
+### EmptyState コンポーネント
+
+```typescript
+// src/components/EmptyState.tsx
+interface EmptyStateProps {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const EmptyState = ({ message, actionLabel, onAction }: EmptyStateProps) => (
+  <div className="empty-state">
+    <p>{message}</p>
+    {actionLabel && onAction && (
+      <button onClick={onAction}>{actionLabel}</button>
+    )}
+  </div>
+);
+```
+
+---
+
+## 7-4. レスポンシブデザイン（モバイルファースト）
+
+### 方針
+
+モバイルファーストで設計し、ブレークポイントで PC 向けレイアウトに拡張する。
+
+### ブレークポイント
+
+| 名前 | 幅 | 対象 |
+|---|---|---|
+| `sm` | 640px〜 | 大きめのスマートフォン |
+| `md` | 768px〜 | タブレット |
+| `lg` | 1024px〜 | デスクトップ |
+
+### CSS 方針
+
+| 方式 | 説明 |
+|---|---|
+| CSS Modules | コンポーネントスコープ。名前衝突なし |
+| Tailwind CSS | ユーティリティファースト。高速開発 |
+| 素の CSS + BEM | シンプル。ライブラリ不要 |
+
+→ **CSS Modules を採用**。理由:
+- Vite が標準サポート（設定不要）
+- コンポーネント単位でスタイルを管理でき、スコープが自然に分離
+- Tailwind ほどの学習コストがなく、通常の CSS 知識で書ける
+- Phase 1 のコンポーネント数なら十分に管理可能
+
+### 主要レイアウトの対応方針
+
+**Header / ナビゲーション**:
+- モバイル: ハンバーガーメニュー
+- デスクトップ: 横並びナビゲーション
+
+**BookshelfPage（本棚グリッド）**:
+- モバイル: 2列グリッド
+- タブレット: 3列
+- デスクトップ: 4〜5列
+
+```css
+.bookshelf-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .bookshelf-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .bookshelf-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+```
+
+**RecordListPage（記録リスト）**:
+- モバイル: カード型の縦並び（フルwidth）
+- デスクトップ: カード型 + 左にフィルターサイドバー
+
+**フォーム（RecordForm, ChildForm 等）**:
+- モバイル: 1列レイアウト
+- デスクトップ: 2列（ラベル左、入力右）or そのまま1列（十分な幅）
+
+**BookDetailPage**:
+- モバイル: サムネイル上、情報下の縦並び
+- デスクトップ: サムネイル左、情報右の横並び
+
+### タッチ操作の考慮
+
+- タップターゲットは最低 44x44px
+- フォーム入力フィールドに十分なパディング
+- スワイプ操作は Phase 1 では不要
+
+---
+
+## 7-5. データベースシーダー（デモデータ）
+
+### 方針
+
+`task fresh` で一発でデモ環境を構築できるシーダーを作成する。開発時の動作確認、デモ、スクリーンショット撮影に使用。
+
+### シーダー構成
+
+```
+backend/database/seeders/
+├── DatabaseSeeder.php          # メインシーダー（各シーダーを呼び出し）
+├── FamilySeeder.php
+├── UserSeeder.php
+├── ChildSeeder.php
+├── PictureBookSeeder.php
+├── ReadRecordSeeder.php
+└── TagSeeder.php
+```
+
+### デモデータ内容
+
+**家族 1: 山田家**
+
+| データ | 内容 |
+|---|---|
+| ユーザー | 山田太郎（パパ）`taro@example.com` / `password` |
+| ユーザー | 山田花子（ママ）`hanako@example.com` / `password` |
+| 子ども | ゆうき（2021-04-15生まれ） |
+| 子ども | あおい（2023-09-20生まれ） |
+| 絵本 | 10〜15冊（各ステータス混在） |
+| 読み聞かせ記録 | 20〜30件（タグ・リアクション付き） |
+
+**家族 2: 佐藤家**（認可テスト用）
+
+| データ | 内容 |
+|---|---|
+| ユーザー | 佐藤一郎 `ichiro@example.com` / `password` |
+| 子ども | さくら（2022-01-10生まれ） |
+| 絵本 | 5冊 |
+| 読み聞かせ記録 | 5件 |
+
+**未所属ユーザー**（招待テスト用）
+
+| データ | 内容 |
+|---|---|
+| ユーザー | 鈴木次郎 `jiro@example.com` / `password` |
+
+### DatabaseSeeder
+
+```php
+namespace Database\Seeders;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->call([
+            FamilySeeder::class,
+            UserSeeder::class,
+            ChildSeeder::class,
+            TagSeeder::class,
+            PictureBookSeeder::class,
+            ReadRecordSeeder::class,
+        ]);
+    }
+}
+```
+
+### PictureBookSeeder のデータ例
+
+実在する絵本のデータを使用（Google Books API のレスポンスを参考に手動で用意）:
+
+| タイトル | 著者 | ステータス | 評価 |
+|---|---|---|---|
+| ぐりとぐら | 中川李枝子 | read | 5 |
+| はらぺこあおむし | エリック・カール | read | 5 |
+| おおきなかぶ | A.トルストイ | read | 4 |
+| ねないこだれだ | せなけいこ | reading | 4 |
+| いないいないばあ | 松谷みよ子 | read | 5 |
+| だるまさんが | かがくいひろし | read | 5 |
+| しろくまちゃんのほっとけーき | わかやまけん | reading | 4 |
+| きんぎょがにげた | 五味太郎 | unread | null |
+| もこもこもこ | 谷川俊太郎 | unread | null |
+| くだもの | 平山和子 | read | 3 |
+
+### TagSeeder のデータ例
+
+```php
+$tags = ['寝る前', 'お気に入り', 'リクエスト', '図書館', '新しい絵本', 'シリーズ', '季節もの'];
+```
+
+### ReadRecordSeeder のデータ例
+
+- 日付は直近1ヶ月にばらけさせる
+- 子どもごとに異なるリアクションを設定
+- 複数タグの紐付け
+
+### 確認ポイント
+
+- `task fresh` でエラーなく完了する
+- 山田太郎でログイン後、本棚・記録・家族設定にデモデータが表示される
+- 佐藤家のデータに山田家からアクセスすると 403 が返る
+
+---
+
+## 7-6. README ドキュメント
+
+### 構成
+
+```markdown
+# 絵本読み聞かせ記録アプリ（Picture Book Log）
+
+## 概要
+家族で絵本の読み聞かせを記録・共有するWebアプリケーション。
+
+## 技術スタック
+（テーブル形式で記載）
+
+## アーキテクチャ
+- DDD + Clean Architecture + CQRS
+- （レイヤー図）
+
+## 環境構築
+
+### 前提条件
+- Docker / Docker Compose
+- Task (go-task)
+
+### セットアップ手順
+1. リポジトリクローン
+2. 環境変数設定（.env.example → .env）
+3. `task up`
+4. `task composer install`
+5. `task artisan key:generate`
+6. `task fresh`
+7. アクセス確認
+
+### アクセス先
+| サービス | URL |
+|---|---|
+| フロントエンド | http://localhost:5173 |
+| API | http://localhost:8080/api/v1 |
+| Mailpit | http://localhost:8025 |
+
+### デモアカウント
+| ユーザー | メール | パスワード |
+|---|---|---|
+
+## 開発コマンド
+（Taskfile.yml のコマンド一覧）
+
+## API エンドポイント一覧
+（全エンドポイントの概要）
+
+## ディレクトリ構成
+（主要ディレクトリの説明）
+```
+
+### 設計判断: README のスコープ
+
+- 環境構築手順に重点を置く（初見の人が迷わずセットアップできること）
+- API の詳細仕様は別途ドキュメント化しない（Phase 1 では README の概要で十分）
+- アーキテクチャの詳細は `docs/plans/rebuild-plan.md` を参照として案内
+
+---
+
+## 7-7. 最終テスト・品質チェック
+
+### バックエンド
+
+```bash
+# 全テスト実行
+task test
+
+# テストカバレッジ確認（任意）
+docker compose exec app php artisan test --coverage
+```
+
+### フロントエンド
+
+Step 7 ではフロントエンドのユニットテストは追加しない（Phase 1 スコープ外）。手動での E2E 確認を行う。
+
+### E2E 手動テストシナリオ
+
+以下のシナリオを一通り手動で確認する:
+
+**シナリオ 1: 新規ユーザーの基本フロー（CRUD 一通り）**
+```
+アカウント登録 → 家族作成 → 子ども追加
+→ 絵本検索・登録 → 絵本の評価・ステータス・レビュー更新
+→ 読み聞かせ記録作成 → 記録編集 → 記録削除
+→ 子ども編集 → 子ども削除
+→ 絵本を本棚から削除
+→ 本棚・記録一覧確認
+```
+
+**シナリオ 2: 招待フロー**
+```
+山田太郎でログイン → 家族設定で招待送信
+→ Mailpit でメール確認
+→ 鈴木次郎でログイン → 招待リンクから受理
+→ 山田家のデータが見える
+```
+
+**シナリオ 3: 認可チェック**
+```
+佐藤一郎でログイン
+→ 山田家の family_id でAPIアクセス → 403
+```
+
+**シナリオ 4: エラーハンドリング**
+```
+未認証で保護ルートにアクセス → ログインページにリダイレクト
+→ バリデーションエラーのあるフォーム送信 → エラー表示
+→ ネットワーク切断 → エラートースト表示
+```
+
+**シナリオ 5: レスポンシブ確認**
+```
+Chrome DevTools でモバイル表示 → 各ページのレイアウト確認
+→ タブレット → デスクトップ
+```
+
+---
+
+## 7-8. 疎通確認チェックリスト
+
+| # | 確認項目 | 方法 | 期待結果 |
+|---|---|---|---|
+| 1 | デモデータ投入 | `task fresh` | エラーなく完了 |
+| 2 | デモアカウントログイン | `taro@example.com` / `password` | ダッシュボード表示 |
+| 3 | ErrorBoundary | コンポーネントで意図的に例外 throw（開発時のみ） | フォールバック UI 表示 |
+| 4 | ローディングスケルトン | 低速ネットワーク (DevTools) でページ遷移 | スケルトン表示 |
+| 5 | 空状態 | 佐藤家で絵本全削除 or 新規家族作成 | メッセージ + アクション導線 |
+| 6 | モバイル表示 | DevTools でモバイルエミュレーション | レイアウト崩れなし |
+| 7 | タブレット表示 | DevTools で 768px 幅 | グリッド列数変化 |
+| 8 | サーバーエラー表示 | API を一時停止してアクセス | トーストエラー表示 |
+| 9 | 401 リダイレクト | トークン削除してページ遷移 | ログインページへ |
+| 10 | 全 Feature テスト | `task test` | 全テスト通過 |
+| 11 | E2E シナリオ 1〜5 | 手動実行 | 全シナリオ成功 |
+| 12 | README 手順 | README に沿って 0 からセットアップ | 環境構築成功 |
+
+---
+
+## 作業順序まとめ
+
+```
+7-1.  グローバルエラーバウンダリ + トースト通知セットアップ
+         ↓
+7-2.  ローディングスケルトン（Skeleton コンポーネント + 各ページ適用）
+         ↓
+7-3.  空状態メッセージ（EmptyState コンポーネント + 各ページ適用）
+         ↓
+7-4.  レスポンシブデザイン（CSS Modules + ブレークポイント対応）
+         ↓
+7-5.  データベースシーダー作成
+         ↓
+7-6.  README ドキュメント作成
+         ↓
+7-7.  最終テスト・品質チェック（Feature テスト + E2E 手動テスト）
+         ↓
+7-8.  疎通確認チェックリスト実行
+```
+
+---
+
+## 注意事項・判断メモ
+
+- **ErrorBoundary はクラスコンポーネント**: React の ErrorBoundary は現時点でクラスコンポーネントでのみ実装可能。関数コンポーネント版は react-error-boundary ライブラリで代替可能だが、Phase 1 では標準 API で十分
+- **トースト通知**: `react-hot-toast` を採用。軽量で API がシンプル
+- **CSS 方針**: CSS Modules。Tailwind CSS は Phase 2 以降で検討
+- **スケルトン**: 自前実装。ライブラリ（react-loading-skeleton 等）は不採用。CSS アニメーションだけで実現できるため
+- **フロントエンドテスト**: Phase 1 ではユニットテスト・E2E テスト（Playwright 等）は導入しない。手動テストのみ
+- **デモデータ**: 実在する絵本のタイトル・著者を使用。サムネイル URL は Google Books からの実際の URL or null
+- **README の維持**: 各 Step 完了時に README を都度更新するのではなく、Step 7 で一括作成する方針。開発中は `docs/plans/` を参照
+- **パフォーマンス最適化**: Phase 1 ではデータ量が限定的なため、特別な最適化（仮想スクロール、画像遅延読み込み等）は行わない。必要になった時点で追加


### PR DESCRIPTION
## Summary

- rebuild-plan.md をベースに、Step 1〜7 の詳細実装プランを個別ファイルとして作成
- 各Step間の整合性チェックを実施し、発見した問題を修正済み
- rebuild-plan.md 自体もスキーマ定義・アーキテクチャ方針を更新

## 新規ファイル

| ファイル | 内容 |
|---|---|
| `step1-project-setup.md` | プロジェクト基盤構築（Docker, Laravel, React） |
| `step2-authentication.md` | 認証（Sanctum トークンベース、Auth DDD構成） |
| `step3-family.md` | 家族管理（Family/Child CRUD、Policy認可） |
| `step4-picture-books.md` | 絵本登録（Google Books API、本棚管理） |
| `step5-read-records.md` | 読み聞かせ記録（子どもごとリアクション、タグ） |
| `step6-invitations.md` | 家族招待（メール送信、トークン受理フロー） |
| `step7-finishing.md` | 仕上げ（ErrorBoundary、スケルトン、レスポンシブ、シーダー） |

## rebuild-plan.md の主な修正

- **コンテキスト間 Value Object 共有方針を追加**: `packages/Shared/ValueObject/` に ID 系 VO を集約する Shared Kernel 方針
- **Phase 1 スキーマの明確化**: `users.role`, `avatar_path`, `soft_delete` を Phase 2 以降に延期と明記、スキーマ表から除外
- **技術スタック**: `react-hot-toast` を追加

## 整合性チェックで修正した主な問題

- コンテキスト間の Value Object 参照方針が未定義 → Shared Kernel 方針を策定
- `registered_by` の `cascadeOnDelete` → `nullOnDelete` に変更（ユーザー削除時に絵本データを保持）
- 手動登録（google_books_id なし）のフロントエンド UI が未設計 → BookManualAddForm を追加
- 各Stepの完了条件・疎通確認チェックリストの漏れを補完

🤖 Generated with [Claude Code](https://claude.com/claude-code)